### PR TITLE
Feat/predict proba index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 ## [Unreleased]
 
 ### Features
+* The `do_predict_proba` parameter of `environment.Environment` (and consequently `models.Model`) is
+now allowed to be an int, as well as a bool. If `do_predict_proba` is an int, the `predict_proba` 
+method is called, and the int specifies the index of the column in the model's probability 
+predictions whose values should be passed on as the final predictions. Original behavior when 
+passing a boolean is unaffected. See `Environment` documentation for usage notes and warnings about 
+providing truthy or falsey values for the `do_predict_proba` parameter 
 
 ### Bug-Fixes
 * Fixed bug causing `OptimizationProtocol`s to fail to recognize similar experiments when 

--- a/hyperparameter_hunter/environment.py
+++ b/hyperparameter_hunter/environment.py
@@ -162,9 +162,20 @@ class Environment:
             'hyperparameter_hunter/examples/lib_keras_multi_classification_example.py'
         id_column: Str, or None, default=None
             If not None, str denoting the column name in all provided datasets containing sample IDs
-        do_predict_proba: Boolean, default=False
-            If True, :meth:`.models.Model.fit` will call :meth:`models.Model.model.predict_proba`.
-            Else, it will call :meth:`models.Model.model.predict`
+        do_predict_proba: Boolean, or int, default=False
+            * If False, :meth:`.models.Model.fit` will call :meth:`models.Model.model.predict`
+            * If True, it will call :meth:`models.Model.model.predict_proba`, and the values in the
+              first column (index 0) will be used as the actual prediction values
+            * If `do_predict_proba` is an int, :meth:`.models.Model.fit` will call
+              :meth:`models.Model.model.predict_proba`, as is the case when `do_predict_proba` is
+              True, but the int supplied as `do_predict_proba` declares the column index to use as
+              the actual prediction values
+            * For example, for a model to call the `predict` method, `do_predict_proba=False`
+              (default). For a model to call the `predict_proba` method, and use the class
+              probabilities in the first column, `do_predict_proba=0` or `do_predict_proba=True`. To
+              use the second column (index 1) of the result, `do_predict_proba=1` - This
+              often corresponds to the positive class's probabilities in binary classification
+              problems. To use the third column `do_predict_proba=2`, and so on
         prediction_formatter: Callable, or None, default=None
             If callable, expected to have same signature as
             :func:`.utils.result_utils.format_predictions`. That is, the callable will receive
@@ -281,6 +292,11 @@ class Environment:
         * 1)kwargs passed directly to :meth:`.Environment.__init__` on initialization,
         * 2)keys of the file at environment_params_path (if valid .json object),
         * 3)keys of :attr:`hyperparameter_hunter.environment.Environment.DEFAULT_PARAMS`
+
+        do_predict_proba: Because this parameter can be either a boolean or an integer, it is
+        important to explicitly pass booleans rather than truthy or falsey values. Similarly, only
+        pass integers if you intend for the value to be used as a column index. Do not pass `0` to
+        mean `False`, or `1` to mean `True`
         """
         G.Env = self
         self.environment_params_path = environment_params_path

--- a/hyperparameter_hunter/models.py
+++ b/hyperparameter_hunter/models.py
@@ -179,11 +179,15 @@ class Model(object):
         input_data: Array-like
             Data containing the same number of features as were trained on, for which the model will
             predict output values"""
+        # NOTE: There are a couple places in this method that use the frowned-upon pattern of
+        # ... `type(<variable>) == <type>`, instead of the preferred use of `isinstance`.
+        # ... This is because booleans are subclasses of integers in Python; however, this method
+        # ... needs to treat them differently, so `isinstance` can't be used
         if input_data is None:
             return None
 
         try:
-            if self.do_predict_proba is True:
+            if (self.do_predict_proba is True) or type(self.do_predict_proba) == int:
                 prediction = self.model.predict_proba(input_data)
             else:
                 prediction = self.model.predict(input_data)
@@ -191,7 +195,8 @@ class Model(object):
             raise _ex
 
         with suppress(IndexError):
-            prediction = prediction[:, 0]
+            _index = self.do_predict_proba if type(self.do_predict_proba) == int else 0
+            prediction = prediction[:, _index]
 
         return prediction
 

--- a/hyperparameter_hunter/models.py
+++ b/hyperparameter_hunter/models.py
@@ -104,9 +104,22 @@ class Model(object):
             The model's validation input data to evaluate performance during fitting
         validation_target: `pandas.DataFrame`, or None
             The true labels corresponding to the rows of :attr:`validation_input`
-        do_predict_proba: Boolean, default=False
-            If True, :meth:`models.Model.fit` will call :meth:`models.Model.model.predict_proba`.
-            Else, it will call :meth:`models.Model.model.predict`
+        do_predict_proba: Boolean, or int, default=False
+            * If False, :meth:`.models.Model.fit` will call :meth:`models.Model.model.predict`
+            * If True, it will call :meth:`models.Model.model.predict_proba`, and the values in the
+              first column (index 0) will be used as the actual prediction values
+            * If `do_predict_proba` is an int, :meth:`.models.Model.fit` will call
+              :meth:`models.Model.model.predict_proba`, as is the case when `do_predict_proba` is
+              True, but the int supplied as `do_predict_proba` declares the column index to use as
+              the actual prediction values
+            * For example, for a model to call the `predict` method, `do_predict_proba=False`
+              (default). For a model to call the `predict_proba` method, and use the class
+              probabilities in the first column, `do_predict_proba=0` or `do_predict_proba=True`. To
+              use the second column (index 1) of the result, `do_predict_proba=1` - This
+              often corresponds to the positive class's probabilities in binary classification
+              problems. To use the third column `do_predict_proba=2`, and so on
+            * See the notes for the `do_predict_proba` parameter in the documentation of
+              :class:`environment.Environment` for additional usage notes
         target_metric: Tuple
             Used by some child classes (like :class:`XGBoostModel`) to provide validation data to
             :meth:`model.fit`
@@ -322,9 +335,22 @@ class KerasModel(Model):
             The model's validation input data to evaluate performance during fitting
         validation_target: `pandas.DataFrame`, or None
             The true labels corresponding to the rows of :attr:`validation_input`
-        do_predict_proba: Boolean, default=False
-            If True, :meth:`Model.fit` will call :meth:`models.Model.model.predict_proba`. Else,
-            it will call :meth:`models.Model.model.predict`
+        do_predict_proba: Boolean, or int, default=False
+            * If False, :meth:`.models.Model.fit` will call :meth:`models.Model.model.predict`
+            * If True, it will call :meth:`models.Model.model.predict_proba`, and the values in the
+              first column (index 0) will be used as the actual prediction values
+            * If `do_predict_proba` is an int, :meth:`.models.Model.fit` will call
+              :meth:`models.Model.model.predict_proba`, as is the case when `do_predict_proba` is
+              True, but the int supplied as `do_predict_proba` declares the column index to use as
+              the actual prediction values
+            * For example, for a model to call the `predict` method, `do_predict_proba=False`
+              (default). For a model to call the `predict_proba` method, and use the class
+              probabilities in the first column, `do_predict_proba=0` or `do_predict_proba=True`. To
+              use the second column (index 1) of the result, `do_predict_proba=1` - This
+              often corresponds to the positive class's probabilities in binary classification
+              problems. To use the third column `do_predict_proba=2`, and so on
+            * See the notes for the `do_predict_proba` parameter in the documentation of
+              :class:`environment.Environment` for additional usage notes
         target_metric: Tuple
             Used by some child classes (like :class:`XGBoostModel`) to provide validation data to
             :meth:`model.fit`


### PR DESCRIPTION
- Closes #90, opened by @caprone
- The `do_predict_proba` parameter of `environment.Environment` (and consequently `models.Model`) is now allowed to be an int, as well as a bool
   - If `do_predict_proba` is an int, the `predict_proba` method is called, and the int specifies the index of the column in the model's probability predictions whose values should be passed on as the final predictions
   - Original behavior when passing a boolean is unaffected
   - See `Environment` documentation for usage notes and warnings about providing truthy or falsey values for the `do_predict_proba` parameter 