### PR TITLE
Fix broken inverse target transformation of LightGBM predictions

### DIFF
--- a/hyperparameter_hunter/data/data_chunks/prediction_chunks.py
+++ b/hyperparameter_hunter/data/data_chunks/prediction_chunks.py
@@ -44,6 +44,11 @@ class BasePredictionChunk(BaseDataChunk):
         self.T.run = deepcopy(prediction)
         self.run = deepcopy(prediction)
 
+        self.run = _format_prediction(self.run, target_column)
+        # `self.run` must be same shape as data transformed by `feature_engineer` prior to inversion
+        # TODO: Make sure this doesn't screw up when no `inverse_transform` call
+        #  Because then it'll just be two consecutive calls to `_format_predictions` with `self.run`
+
         with suppress(AttributeError):  # TODO: Drop `suppress` - Was for `feature_engineer={}`
             # NOTE: How does `FeatureEngineer` know these are predictions to invert, not inputs?
             #   Probably need to make an assumption for now, albeit a fairly safe one
@@ -60,6 +65,7 @@ class BasePredictionChunk(BaseDataChunk):
         #   Might be able to use transformed `data_holdout.target` to figure it out - Not pretty
 
     def on_fold_end(self, runs: int, *args, **kwargs):
+        # TODO: For all `/=` ops herein, conditionally do floor div if `self.run` is non-continuous?
         self.fold /= runs
         self.rep += self.fold
         self.T.fold /= runs

--- a/hyperparameter_hunter/optimization_core.py
+++ b/hyperparameter_hunter/optimization_core.py
@@ -54,6 +54,7 @@ from datetime import datetime
 from inspect import currentframe, getframeinfo
 from os import walk, remove, rmdir
 from os.path import abspath
+from typing import Any, Dict
 
 ##################################################
 # Import Learning Assets
@@ -442,20 +443,35 @@ class BaseOptimizationProtocol(metaclass=MergedOptimizationMeta):
         if self.module_name == "keras":
             K.clear_session()
 
+    @staticmethod
+    def _select_params(param_prefix: str, current_params: Dict[tuple, Any]):
+        """Retrieve sub-dict of `current_params` whose keys start with `param_prefix`
+
+        Parameters
+        ----------
+        param_prefix: {"model_init_params", "model_extra_params", "feature_engineer"}
+            Target to filter keys of `current_params`. Only key/value pairs in `current_params`
+            whose keys start with `param_prefix` are returned. `param_prefix` is dropped from the
+            keys in the returned dict
+        current_params: Dict[tuple, Any]
+            Dict from which to return the subset whose keys start with `param_prefix`
+
+        Returns
+        -------
+        Dict[tuple, Any]
+            Contents of `current_params`, whose keys started with `param_prefix` - with
+            `param_prefix` dropped from the resulting keys"""
+        return {k[1:]: v for k, v in current_params if k[0] == param_prefix}
+
     def _update_current_hyperparameters(self):
         """Update :attr:`current_init_params`, and :attr:`current_extra_params` according to the
         upcoming set of hyperparameters to be searched"""
         current_hyperparameters = self._get_current_hyperparameters().items()
 
-        init_params = {
-            _k[1:]: _v for _k, _v in current_hyperparameters if _k[0] == "model_init_params"
-        }
-        extra_params = {
-            _k[1:]: _v for _k, _v in current_hyperparameters if _k[0] == "model_extra_params"
-        }
-        fe_params = {
-            _k[1:]: _v for _k, _v in current_hyperparameters if _k[0] == "feature_engineer"
-        }
+        init_params = self._select_params("model_init_params", current_hyperparameters)
+        extra_params = self._select_params("model_extra_params", current_hyperparameters)
+        fe_params = self._select_params("feature_engineer", current_hyperparameters)
+
         # TODO: Add `fs_params` for `current_feature_selector`
 
         # FLAG: At this point, `dummy_layers` shows "kernel_initializer" as `orthogonal` instance with "__hh" attrs

--- a/hyperparameter_hunter/space.py
+++ b/hyperparameter_hunter/space.py
@@ -38,6 +38,11 @@ from skopt.space import space as skopt_space
 class Singleton(type):
     _instances = {}
 
+    def __new__(mcs, name, bases, namespace):
+        namespace["__copy__"] = lambda self, *args: self
+        namespace["__deepcopy__"] = lambda self, *args: self
+        return super().__new__(mcs, name, bases, namespace)
+
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
             cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)


### PR DESCRIPTION
- This change fixes experiments using `LGBMRegressor` with a `feature_engineer`
  that performs a quantile target transformation and inversion
- Steps to reproduce:
   1. Comment out the single line of code added by this commit
   2. Open `hyperparameter_hunter/examples/lightgbm_examples/regression.py`
   3. Add the following feature engineer step function:

   ```python
   from sklearn.preprocessing import QuantileTransformer

   def quantile_transform(train_targets, non_train_targets):
       transformer = QuantileTransformer(output_distribution="normal", n_quantiles=100)
       train_targets[train_targets.columns] = transformer.fit_transform(train_targets.values)
       non_train_targets[train_targets.columns] = transformer.transform(non_train_targets.values)
       return train_targets, non_train_targets, transformer
   ```
   4. Add `feature_engineer=FeatureEngineer([quantile_transform])` to the `CVExperiment`
- Following above steps should raise `ValueError: Expected 2D array, got 1D array instead`

- Seems that LightGBM is the only library to return 1-dimensional predictions given
  the opportunity; however, this problem could certainly be caused by some weird stuff I'm
  doing elsewhere...