### PR TITLE
Remove `Mirror`/`TranslateTrace`

### DIFF
--- a/hyperparameter_hunter/environment.py
+++ b/hyperparameter_hunter/environment.py
@@ -668,38 +668,6 @@ class Environment:
         G.debug = reporting_handler.debug
         G.warn = reporting_handler.warn
 
-    # @property
-    # def initialized_model(self):
-    #     """Sentinel for use with meta-estimators, such as those in SKLearn's `multioutput` module
-    #
-    #     When declaring `model_init_params` for the meta-estimator during `CVExperiment`
-    #     or optimization protocol setup, provide this property as input to the meta-estimator's
-    #     `estimator`/`base_estimator` parameter.
-    #
-    #     This property is actually a placeholder for the initialized model created by whatever model
-    #     is at the index following the current index. For example, assuming a properly initialized
-    #     `Environment`, to use a Support Vector Regression in a multi-regression problem...
-    #     >>> from hyperparameter_hunter import CVExperiment
-    #     >>> from sklearn.multioutput import MultiOutputRegressor
-    #     >>> from sklearn.svm import SVR
-    #     >>> env = Environment(...)
-    #     >>> experiment = CVExperiment(
-    #     ...     model_initializer=(MultiOutputRegressor, SVR),
-    #     ...     model_init_params=(  # Dict of parameters for each `model_initializer`
-    #     ...         dict(estimator=env.initialized_model),  # References model following current model (`SVR` at index 1)
-    #     ...         dict(kernel="linear", C=10.0),
-    #     ...     )
-    #     ... )
-    #     What happens behind the scenes is that because the first set of `model_init_params` contains
-    #     the sentinel for another initialized model, its initialization is delayed until the others
-    #     have been initialized.
-    #     So the `SVR` is initialized with `dict(kernel="linear", C=10.0)`. Then the initialized SVR
-    #     is provided as input to the model that preceded it and declared the initialized SVR as
-    #     input: the `MultiOutputRegressor`. The end result is a model that can be parameterized by
-    #     HyperparameterHunter that mirrors the following:
-    #     >>> MultiOutputRegressor(estimator=SVR(kernel="linear", C=10.0))
-    #     """
-
     ##################################################
     # Dataset Sentinels for Use as Extra Parameters
     ##################################################

--- a/hyperparameter_hunter/experiments.py
+++ b/hyperparameter_hunter/experiments.py
@@ -40,8 +40,6 @@ from hyperparameter_hunter.metrics import ScoringMixIn, get_formatted_target_met
 from hyperparameter_hunter.models import model_selector
 from hyperparameter_hunter.recorders import RecorderList
 from hyperparameter_hunter.settings import G
-
-# from hyperparameter_hunter.tracers import TranslateTrace  # TODO: Add when tested with `Mirror`
 from hyperparameter_hunter.utils.file_utils import RetryMakeDirs
 from hyperparameter_hunter.utils.general_utils import Deprecated
 
@@ -73,14 +71,9 @@ np.random.seed(32)
 
 
 class BaseExperiment(ScoringMixIn):
-    # @TranslateTrace("model", ("model_initializer", "model_init_params"))  # TODO: Add when tested with `Mirror`
     def __init__(
         # TODO: Make `model_init_params` an optional kwarg - If not given, algorithm defaults used
         self,
-        # model=None,
-        # model_initializer=None,
-        # model_init_params=None,
-        # TODO: Convert below 2 to above 3 lines for `TranslateTrace`
         model_initializer,
         model_init_params,
         model_extra_params=None,
@@ -91,10 +84,6 @@ class BaseExperiment(ScoringMixIn):
         auto_start=True,
         target_metric=None,
     ):
-        # TODO: When `TranslateTrace` added document `model` below with expectation that if `model`
-        # TODO: ... given, (`model_initializer`, `model_init_params`) should not be, and vice versa
-        # TODO: `model` (Class instance, default=None);
-        # TODO: `model_initializer`/`model_init_params` docstring types += "default=None"
         """Base class for :class:`BaseCVExperiment`
 
         Parameters
@@ -139,7 +128,6 @@ class BaseExperiment(ScoringMixIn):
             :func:`metrics.get_formatted_target_metric` for more info. Any values returned by, or
             used as the `target_metric` input to this function are acceptable values for
             :attr:`BaseExperiment.target_metric`"""
-        # self._model_original = model  # TODO: Add for `TranslateTrace`
         self.model_initializer = model_initializer
         self.model_init_params = identify_algorithm_hyperparameters(self.model_initializer)
         try:
@@ -464,10 +452,6 @@ class BaseExperiment(ScoringMixIn):
 class BaseCVExperiment(BaseExperiment):
     def __init__(
         self,
-        # model=None,
-        # model_initializer=None,
-        # model_init_params=None,
-        # TODO: Convert below 2 to above 3 lines for `TranslateTrace`
         model_initializer,
         model_init_params,
         model_extra_params=None,
@@ -493,10 +477,6 @@ class BaseCVExperiment(BaseExperiment):
 
         BaseExperiment.__init__(
             self,
-            # model=model,
-            # model_initializer=model_initializer,
-            # model_init_params=model_init_params,
-            # TODO: Convert below 2 to above 3 lines for `TranslateTrace`
             model_initializer,
             model_init_params,
             model_extra_params=model_extra_params,
@@ -637,10 +617,6 @@ class BaseCVExperiment(BaseExperiment):
 class CVExperiment(BaseCVExperiment, metaclass=ExperimentMeta):
     def __init__(
         self,
-        # model=None,
-        # model_initializer=None,
-        # model_init_params=None,
-        # TODO: Convert below 2 to above 3 lines for `TranslateTrace`
         model_initializer,
         model_init_params,
         model_extra_params=None,
@@ -653,10 +629,6 @@ class CVExperiment(BaseCVExperiment, metaclass=ExperimentMeta):
     ):
         BaseCVExperiment.__init__(
             self,
-            # model=model,
-            # model_initializer=model_initializer,
-            # model_init_params=model_init_params,
-            # TODO: Convert below 2 to above 3 lines for `TranslateTrace`
             model_initializer,
             model_init_params,
             model_extra_params=model_extra_params,

--- a/hyperparameter_hunter/keys/hashing.py
+++ b/hyperparameter_hunter/keys/hashing.py
@@ -1,9 +1,4 @@
 ##################################################
-# Import Own Assets
-##################################################
-from hyperparameter_hunter.settings import G
-
-##################################################
 # Import Miscellaneous Assets
 ##################################################
 import base64
@@ -11,7 +6,6 @@ from functools import partial
 import hashlib
 from inspect import getsourcelines
 import re
-import sys
 
 
 def make_hash_sha256(obj, **kwargs):
@@ -114,20 +108,8 @@ def hash_callable(
 
     #################### Format Source Code Lines ####################
     if not ignore_source_lines:
-        # TODO: Below only works on modified Keras `build_fn` during optimization if temp file still exists
-        # FLAG: May need to wrap below in try/except TypeError to handle "built-in class" errors during mirroring
-        # FLAG: ... Reference `settings.G.mirror_registry` for approval and its `original_sys_module_entry` attribute
-        try:
-            source_lines = getsourcelines(obj)[0]
-        except TypeError as _ex:
-            for a_mirror in G.mirror_registry:
-                if obj.__name__ == a_mirror.import_name:
-                    # TODO: Also, check `a_mirror.original_full_path` somehow, or object equality
-                    source_lines = a_mirror.asset_source_lines[0]
-                    break
-            else:
-                raise _ex.with_traceback(sys.exc_traceback)
-        # TODO: Above only works on modified Keras `build_fn` during optimization if temp file still exists
+        # TODO: Only works on modified Keras `build_fn` in optimization if temp file still exists
+        source_lines = getsourcelines(obj)[0]
 
         if ignore_line_comments:
             source_lines = [_ for _ in source_lines if not is_line_comment(_)]

--- a/hyperparameter_hunter/keys/makers.py
+++ b/hyperparameter_hunter/keys/makers.py
@@ -41,7 +41,7 @@ from abc import ABCMeta, abstractmethod
 from copy import deepcopy
 import dill  # TODO: Figure out if this can be safely removed
 from functools import partial
-from inspect import getsourcelines, isclass, getsource
+from inspect import isclass, getsource
 from os import listdir
 import os.path
 import pandas as pd
@@ -180,16 +180,8 @@ class KeyMaker(metaclass=ABCMeta):
                 return (key, keras_initializer_to_dict(value))
             if isinstance(value, Sentinel):
                 return (key, value.sentinel)
-            # from hyperparameter_hunter.feature_engineering import FeatureEngineer, EngineerStep
-            # if isinstance(value, EngineerStep):
-            #     return (key, value.get_key_data())
-            # if isinstance(value, FeatureEngineer):
-            #     return (key, value.get_key_data())
             elif callable(value) or isinstance(value, pd.DataFrame):
-                # TODO: Check here if callable, and using a `Trace`d model/model_initializer
-                # TODO: If so, pass extra kwargs to below `make_hash_sha256`, which are eventually given to `hash_callable`
-                # TODO: Notably, `ignore_source_lines=True` should be included
-                # FLAG: Also, look into adding package version number to hashed attributes
+                # FLAG: Look into adding package version number to hashed attributes
                 hashed_value = make_hash_sha256(value)
 
                 if isinstance(value, pd.DataFrame):
@@ -230,15 +222,7 @@ class KeyMaker(metaclass=ABCMeta):
 
             with shelve.open(lookup_path(f"{key}"), flag="c") as s:
                 # NOTE: When reading from shelve file, DO NOT add the ".db" file extension
-                try:
-                    s[hashed_value] = value
-                except PicklingError:
-                    # "is not the same object" error can be raised due to `Mirror`/`TranslateTrace`
-                    # Instead of saving the object that raised the error, save `getsourcelines`
-                    # Source lines of traced object are identical to those of its un-traced original
-                    s[hashed_value] = getsourcelines(value)
-                except Exception:
-                    raise
+                s[hashed_value] = value
         elif isinstance(value, pd.DataFrame):
             make_dirs(lookup_path(key), exist_ok=True)
             value.to_csv(lookup_path(key, f"{hashed_value}.csv"), index=False)

--- a/hyperparameter_hunter/optimization_core.py
+++ b/hyperparameter_hunter/optimization_core.py
@@ -192,7 +192,6 @@ class BaseOptimizationProtocol(metaclass=MergedOptimizationMeta):
     ##################################################
     # Core Methods:
     ##################################################
-    # TODO: Add `model` here, with a `TranslateTrace` decorator, and document it below
     def set_experiment_guidelines(
         self,
         model_initializer,
@@ -404,7 +403,6 @@ class BaseOptimizationProtocol(metaclass=MergedOptimizationMeta):
 
         #################### Initialize Experiment (Without Running) ####################
         self.current_experiment = CVExperiment(
-            # model=None,  # TODO: May need to pass `model` from `set_experiment_guidelines`
             model_initializer=self.model_initializer,
             model_init_params=self.current_init_params,
             model_extra_params=self.current_extra_params,

--- a/hyperparameter_hunter/settings.py
+++ b/hyperparameter_hunter/settings.py
@@ -133,8 +133,6 @@ class G(object):
         ...
     sentinel_registry: List
         ...
-    mirror_registry: List
-        ...
     """
 
     Env = None
@@ -172,7 +170,6 @@ class G(object):
 
     import_hooks = []
     sentinel_registry = []
-    mirror_registry = []
 
     @classmethod
     def reset_attributes(cls):

--- a/hyperparameter_hunter/tracers.py
+++ b/hyperparameter_hunter/tracers.py
@@ -22,7 +22,6 @@ from hyperparameter_hunter.space import Real, Integer, Categorical
 ##################################################
 # noinspection PyProtectedMember
 from inspect import signature, _empty, currentframe, getframeinfo
-from functools import wraps
 
 
 class ArgumentTracer(type):
@@ -92,93 +91,3 @@ class LocationTracer(ArgumentTracer):
         setattr(instance, "__hh_previous_frame", previous_frame_info)
 
         return instance
-
-
-class TranslateTrace:
-    def __init__(self, traced_parameter_name, translated_names=None):
-        """Decorator to convert a class instance passed through one parameter into the class and
-        the parameters used to initialize the instance. The translated values are then passed to the
-        decorated callable through two other parameters named by `translated_names`, while the
-        original value passed through `traced_parameter_name` is erased
-
-        Parameters
-        ----------
-        traced_parameter_name: String
-            Name of the parameter that is expected to receive a traced object instance as input
-        translated_names: Tuple, None, default=None
-            Names of the parameters to which the translations of the traced object should be passed
-
-        Notes
-        -----
-        For a `traced_parameter_name` value of a class instance, the values passed through the
-        `translated_names` parameters will be (respectively) 1) the class of which the value of
-        `traced_parameter_name` is an instance, and 2) the dict of parameters used to initialize
-        the instance of the class"""
-        self.traced_parameter_name = traced_parameter_name
-        self.translated_names = translated_names
-
-    def __call__(self, obj):
-        """
-        # TODO: Documentation description
-
-        Parameters
-        ----------
-        obj: Object
-            Decorated callable, which is expected to receive a traced object as input, but will be
-            passed its translation via the parameters in :attr:`translated_names`, instead
-
-        Returns
-        -------
-        Object
-            Callable  # TODO: Documentation
-        """
-
-        @wraps(obj)
-        def wrapped(*args, **kwargs):
-            binding = signature(obj).bind_partial(*args, **kwargs)
-
-            #################### Traced Parameter Unused ####################
-            if not binding.arguments[self.traced_parameter_name]:
-                # Traced parameter not given. Do nothing, and proceed normally
-                return obj(*args, **kwargs)
-
-            #################### Traced Parameter Used ####################
-            if any(binding.arguments[_] for _ in self.translated_names):
-                # Traced parameter and target translations both given. Only expected one
-                raise ValueError(
-                    "Received both `{0}` and at least one of: {1}. Expected one of following:\n"
-                    + " - 1) Both of [{1}] are given, and `{0}` is not given; or\n"
-                    + " - 2) `{0}` is given, and neither of [{1}] are given".format(
-                        self.traced_parameter_name, self.translated_names
-                    )
-                )
-
-            # Traced parameter was given, and target translations were not given
-            # TODO: Generalize below to use `traced_parameter_name` and `translated_names`
-            binding.arguments["model_initializer"] = binding.arguments["model"].__class__
-
-            # FLAG: ATTEMPT TO RESTORE ASSET FOR HASHING, BUT IT'S PROBABLY SCREWING SHIT UP
-            #################### Replace Traced Asset with Original ####################
-            # target_module = binding.arguments["model_initializer"].__module__
-            # target_asset = binding.arguments["model_initializer"].__name__
-            # for a_mirror in G.mirror_registry:
-            #     if a_mirror.module_path == target_module and a_mirror.import_name == target_asset:
-            #         # Found mirrored asset
-            #         sys.modules[a_mirror.module_path] = a_mirror.original_sys_module_entry
-            #         binding.arguments["model_initializer"] = getattr(
-            #             a_mirror.original_module, target_asset
-            #         )
-            #         break
-            # FLAG: ATTEMPT TO RESTORE ASSET FOR HASHING, BUT IT'S PROBABLY SCREWING SHIT UP
-
-            translation_binding = signature(binding.arguments["model_initializer"]).bind_partial(
-                *getattr(binding.arguments["model"], "__hh_used_args"),
-                **getattr(binding.arguments["model"], "__hh_used_kwargs"),
-            )
-            binding.arguments["model_init_params"] = translation_binding.arguments
-            binding.arguments["model"] = None
-            # TODO: Generalize above to use `traced_parameter_name` and `translated_names`
-
-            return obj(*binding.args, **binding.kwargs)
-
-        return wrapped


### PR DESCRIPTION
- Cleans out unused code/comments concerning development of `Mirror`/`TranslateTrace` features
- Original content preserved in a separate, long-term development branch - See PR #143 
- Should not be included on master branch, since it's still in development