### PR TITLE
Shorten `on_experiment...`/`on_repetition...` method names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <a name="Unreleased"></a>
 ## [Unreleased]
 
+### Changes
+* `model_init_params` kwarg of `CVExperiment` is now optional. If not given, it will be evaluated 
+  as the default initialization parameters to `model_initializer`
+
 
 <a name="3.0.0alpha2"></a>
 ## [3.0.0alpha2] (2019-06-12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 * `model_init_params` kwarg of `CVExperiment` is now optional. If not given, it will be evaluated 
   as the default initialization parameters to `model_initializer`
 
+### Deprecations
+* `lambda_callback` kwargs dealing with "experiment" and "repetition" time steps have been shortened
+    * These four kwargs have been changed to the following values:
+        * `on_experiment_start` -> `on_exp_start`
+        * `on_experiment_end` -> `on_exp_end`
+        * `on_repetition_start` -> `on_rep_start`
+        * `on_repetition_end` -> `on_rep_end`
+    * In summary, "experiment" is shortened to "exp", and "repetition" is shortened to "rep"
+    * The originals will continue to be available until their removal in v3.2.0
+    * This deprecation will break any custom callbacks created by subclassing `BaseCallback` (which 
+      is not the officially supported method), rather than using `lambda_callback`
+        * To fix such callbacks, simply rename the above methods
 
 <a name="3.0.0alpha2"></a>
 ## [3.0.0alpha2] (2019-06-12)

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -17,3 +17,9 @@ ul.simple {
 /*div.related {*/
     /*background-color: #a80b00;*/
 /*}*/
+
+div.warning, div.deprecated {
+    color: #b94a48;
+    background-color: #F3E5E5;
+    border: 1px solid #eed3d7;
+}

--- a/docs/source/hyperparameter_hunter.utils.rst
+++ b/docs/source/hyperparameter_hunter.utils.rst
@@ -60,6 +60,14 @@ hyperparameter\_hunter.utils.result\_utils module
     :undoc-members:
     :show-inheritance:
 
+hyperparameter\_hunter.utils.version\_utils module
+--------------------------------------------------
+
+.. automodule:: hyperparameter_hunter.utils.version_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Module contents
 ---------------

--- a/examples/advanced_examples/lambda_callback_example.py
+++ b/examples/advanced_examples/lambda_callback_example.py
@@ -16,10 +16,10 @@ def printer_callback():
         print(f"{_rep}.{_fold}.{_run}   {last_evaluation_results}")
 
     return lambda_callback(
-        on_experiment_start=printer_helper,
-        on_experiment_end=printer_helper,
-        on_repetition_start=printer_helper,
-        on_repetition_end=printer_helper,
+        on_exp_start=printer_helper,
+        on_exp_end=printer_helper,
+        on_rep_start=printer_helper,
+        on_rep_end=printer_helper,
         on_fold_start=printer_helper,
         on_fold_end=printer_helper,
         on_run_start=printer_helper,

--- a/hyperparameter_hunter/callbacks/aggregators.py
+++ b/hyperparameter_hunter/callbacks/aggregators.py
@@ -16,17 +16,17 @@ class AggregatorTimes(BaseAggregatorCallback):
     _fold: int
     _run: int
 
-    def on_experiment_start(self):
+    def on_exp_start(self):
         self.stat_aggregates.setdefault(
             "times", dict(runs=[], folds=[], reps=[], total_elapsed=None, start=None, end=None)
         )
         self.stat_aggregates["times"]["start"] = str(datetime.now())
         self.stat_aggregates["times"]["total_elapsed"] = datetime.now()
-        super().on_experiment_start()
+        super().on_exp_start()
 
-    def on_repetition_start(self):
+    def on_rep_start(self):
         self.stat_aggregates["times"]["reps"].append(datetime.now())
-        super().on_repetition_start()
+        super().on_rep_start()
 
     def on_fold_start(self):
         self.stat_aggregates["times"]["folds"].append(datetime.now())
@@ -44,11 +44,11 @@ class AggregatorTimes(BaseAggregatorCallback):
         self.__to_elapsed("folds")
         super().on_fold_end()
 
-    def on_repetition_end(self):
+    def on_rep_end(self):
         self.__to_elapsed("reps")
-        super().on_repetition_end()
+        super().on_rep_end()
 
-    def on_experiment_end(self):
+    def on_exp_end(self):
         #################### Reshape Run/Fold Aggregates to be of Proper Dimensions ####################
         runs_shape = (self._rep + 1, self._fold + 1, self._run + 1)
         folds_shape = (self._rep + 1, self._fold + 1)
@@ -59,7 +59,7 @@ class AggregatorTimes(BaseAggregatorCallback):
 
         self.stat_aggregates["times"]["end"] = str(datetime.now())
         self.__to_elapsed("total_elapsed")
-        super().on_experiment_end()
+        super().on_exp_end()
 
     def __to_elapsed(self, agg_key):
         # TODO: Add documentation
@@ -103,12 +103,12 @@ class AggregatorEvaluations(BaseAggregatorCallback):
             agg_val["folds"].append(self.__loop_helper(agg_key))
         super().on_fold_end()
 
-    def on_repetition_end(self):
+    def on_rep_end(self):
         for agg_key, agg_val in self.stat_aggregates["evaluations"].items():
             agg_val["reps"].append(self.__loop_helper(agg_key))
-        super().on_repetition_end()
+        super().on_rep_end()
 
-    def on_experiment_end(self):
+    def on_exp_end(self):
         for agg_key, agg_val in self.stat_aggregates["evaluations"].items():
             agg_val["final"] = self.__loop_helper(agg_key)
 
@@ -117,7 +117,7 @@ class AggregatorEvaluations(BaseAggregatorCallback):
             agg_val["runs"] = np.reshape(agg_val["runs"], runs_shape).tolist()
             agg_val["folds"] = np.reshape(agg_val["folds"], runs_shape[:-1]).tolist()
 
-        super().on_experiment_end()
+        super().on_exp_end()
 
     def __loop_helper(self, agg_key):
         # TODO: Add documentation

--- a/hyperparameter_hunter/callbacks/evaluators.py
+++ b/hyperparameter_hunter/callbacks/evaluators.py
@@ -36,21 +36,21 @@ class EvaluatorOOF(BaseEvaluatorCallback):
             self.evaluate("oof", self.data_oof.target.fold, self.data_oof.prediction.fold)
         super().on_fold_end()
 
-    def on_repetition_end(self):
+    def on_rep_end(self):
         """Evaluate (run-averaged) out-of-fold predictions for the repetition"""
         if G.save_transformed_metrics:
             self.evaluate("oof", self.data_oof.target.T.rep, self.data_oof.prediction.T.rep)
         else:
             self.evaluate("oof", self.data_oof.target.rep, self.data_oof.prediction.rep)
-        super().on_repetition_end()
+        super().on_rep_end()
 
-    def on_experiment_end(self):
+    def on_exp_end(self):
         """Evaluate final (run/repetition-averaged) out-of-fold predictions"""
         if G.save_transformed_metrics:
             self.evaluate("oof", self.data_oof.target.T.final, self.data_oof.prediction.T.final)
         else:
             self.evaluate("oof", self.data_oof.target.final, self.data_oof.prediction.final)
-        super().on_experiment_end()
+        super().on_exp_end()
 
 
 class EvaluatorHoldout(BaseEvaluatorCallback):
@@ -78,7 +78,7 @@ class EvaluatorHoldout(BaseEvaluatorCallback):
             )
         super().on_fold_end()
 
-    def on_repetition_end(self):
+    def on_rep_end(self):
         """Evaluate (run-averaged) holdout predictions for the repetition"""
         if G.save_transformed_metrics:
             self.evaluate(
@@ -86,9 +86,9 @@ class EvaluatorHoldout(BaseEvaluatorCallback):
             )
         else:
             self.evaluate("holdout", self.data_holdout.target.rep, self.data_holdout.prediction.rep)
-        super().on_repetition_end()
+        super().on_rep_end()
 
-    def on_experiment_end(self):
+    def on_exp_end(self):
         """Evaluate final (run/repetition-averaged) holdout predictions"""
         if G.save_transformed_metrics:
             self.evaluate(
@@ -98,4 +98,4 @@ class EvaluatorHoldout(BaseEvaluatorCallback):
             self.evaluate(
                 "holdout", self.data_holdout.target.final, self.data_holdout.prediction.final
             )
-        super().on_experiment_end()
+        super().on_exp_end()

--- a/hyperparameter_hunter/callbacks/loggers.py
+++ b/hyperparameter_hunter/callbacks/loggers.py
@@ -29,14 +29,14 @@ class LoggerFitStatus(BaseLoggerCallback):
     log_separator = "  |  "
     # FLAG: Add means of updating float_format to "G.Env.reporting_params['float_format']"
 
-    def on_experiment_start(self):
+    def on_exp_start(self):
         G.log("", previous_frame=inspect.currentframe().f_back)
-        super().on_experiment_start()
+        super().on_exp_start()
 
-    def on_repetition_start(self):
+    def on_rep_start(self):
         if G.Env.verbose >= 3 and G.Env.cv_params.get("n_repeats", 1) > 1:
             G.log("", previous_frame=inspect.currentframe().f_back)
-        super().on_repetition_start()
+        super().on_rep_start()
 
     def on_fold_start(self):
         if G.Env.verbose >= 4 and G.Env.runs > 1:
@@ -80,7 +80,7 @@ class LoggerFitStatus(BaseLoggerCallback):
             G.debug(content, previous_frame=inspect.currentframe().f_back, add_time=False)
         super().on_fold_end()
 
-    def on_repetition_end(self):
+    def on_rep_end(self):
         content = format_fold_run(rep=self._rep, fold="-", run="-")
         content += self.log_separator if not content.endswith(" ") else ""
         content += format_evaluation(self.last_evaluation_results, float_format=self.float_format)
@@ -91,9 +91,9 @@ class LoggerFitStatus(BaseLoggerCallback):
             G.log(content, previous_frame=inspect.currentframe().f_back)
         else:
             G.debug(content, previous_frame=inspect.currentframe().f_back)
-        super().on_repetition_end()
+        super().on_rep_end()
 
-    def on_experiment_end(self):
+    def on_exp_end(self):
         content = "FINAL:    "
 
         content += format_evaluation(self.last_evaluation_results, float_format=self.float_format)
@@ -102,7 +102,7 @@ class LoggerFitStatus(BaseLoggerCallback):
 
         G.log("")
         G.log(content, previous_frame=inspect.currentframe().f_back, add_time=False)
-        super().on_experiment_end()
+        super().on_exp_end()
 
     def __elapsed_helper(self, period):
         times = self.stat_aggregates["times"]

--- a/hyperparameter_hunter/callbacks/recipes.py
+++ b/hyperparameter_hunter/callbacks/recipes.py
@@ -42,7 +42,7 @@ from sklearn.metrics import confusion_matrix as sk_confusion_matrix
 ##################################################
 # Confusion Matrix Callbacks
 ##################################################
-def confusion_matrix_oof(on_run=True, on_fold=True, on_repetition=True, on_experiment=True):
+def confusion_matrix_oof(on_run=True, on_fold=True, on_rep=True, on_exp=True):
     """Callback function to produce confusion matrices for out-of-fold predictions at each stage of
     the Experiment
 
@@ -52,9 +52,9 @@ def confusion_matrix_oof(on_run=True, on_fold=True, on_repetition=True, on_exper
         If False, skip making confusion matrices for individual Experiment runs
     on_fold: Boolean, default=True
         If False, skip making confusion matrices for individual Experiment folds
-    on_repetition: Boolean, default=True
+    on_rep: Boolean, default=True
         If False, skip making confusion matrices for individual Experiment repetitions
-    on_experiment: Boolean, default=True
+    on_exp: Boolean, default=True
         If False, skip making final confusion matrix for the Experiment
 
     Returns
@@ -108,7 +108,7 @@ def confusion_matrix_oof(on_run=True, on_fold=True, on_repetition=True, on_exper
             data_oof.target.fold, data_oof.prediction.rep.iloc[validation_index]
         )
 
-    def _on_repetition_end(data_train, data_oof):
+    def _on_rep_end(data_train, data_oof):
         """Callback to execute upon ending an Experiment's repetition. Note that parameters are
         named after Experiment attributes
 
@@ -125,7 +125,7 @@ def confusion_matrix_oof(on_run=True, on_fold=True, on_repetition=True, on_exper
         # return _confusion_matrix(data_oof.target.final, data_oof.prediction.rep)  # TODO: Should use this when collecting transformed targets
         return _confusion_matrix(data_train.target.d, data_oof.prediction.rep)  # FLAG: TEMPORARY
 
-    def _on_experiment_end(data_train, data_oof):
+    def _on_exp_end(data_train, data_oof):
         """Callback to execute upon ending an Experiment. Note that parameters are
         named after Experiment attributes
 
@@ -145,13 +145,13 @@ def confusion_matrix_oof(on_run=True, on_fold=True, on_repetition=True, on_exper
     return lambda_callback(
         on_run_end=_on_run_end if on_run else None,
         on_fold_end=_on_fold_end if on_fold else None,
-        on_repetition_end=_on_repetition_end if on_repetition else None,
-        on_experiment_end=_on_experiment_end if on_experiment else None,
+        on_rep_end=_on_rep_end if on_rep else None,
+        on_exp_end=_on_exp_end if on_exp else None,
         agg_name="confusion_matrix_oof",
     )
 
 
-def confusion_matrix_holdout(on_run=True, on_fold=True, on_repetition=True, on_experiment=True):
+def confusion_matrix_holdout(on_run=True, on_fold=True, on_rep=True, on_exp=True):
     """Callback function to produce confusion matrices for holdout predictions at each stage of
     the Experiment
 
@@ -161,9 +161,9 @@ def confusion_matrix_holdout(on_run=True, on_fold=True, on_repetition=True, on_e
         If False, skip making confusion matrices for individual Experiment runs
     on_fold: Boolean, default=True
         If False, skip making confusion matrices for individual Experiment folds
-    on_repetition: Boolean, default=True
+    on_rep: Boolean, default=True
         If False, skip making confusion matrices for individual Experiment repetitions
-    on_experiment: Boolean, default=True
+    on_exp: Boolean, default=True
         If False, skip making final confusion matrix for the Experiment
 
     Returns
@@ -179,7 +179,7 @@ def confusion_matrix_holdout(on_run=True, on_fold=True, on_repetition=True, on_e
     functions. It does this simply by not returning values in the "on..." functions, and manually
     aggregating the stats in :attr:`hyperparameter_hunter.experiments.BaseExperiment.stat_aggregates`.
     This offers greater control over how your values are collected, but also requires additional
-    overhead, namely, instantiating a dict to collect the values via :func:`_on_experiment_start`.
+    overhead, namely, instantiating a dict to collect the values via :func:`_on_exp_start`.
     Note also that each of the "on..." functions must append their values to an explicitly named
     container in :attr:`hyperparameter_hunter.experiments.BaseExperiment.stat_aggregates` when using
     this method as opposed to :func:`hyperparameter_hunter.callbacks.recipes.confusion_matrix_oof`\'s
@@ -187,7 +187,7 @@ def confusion_matrix_holdout(on_run=True, on_fold=True, on_repetition=True, on_e
     If the size of this `lambda_callback` implementation is daunting, minimize the helper functions'
     docstrings. It's surprisingly simple"""
 
-    def _on_experiment_start(stat_aggregates):
+    def _on_exp_start(stat_aggregates):
         """Callback to instantiate container for Experiment values to be aggregated
 
         Parameters
@@ -224,7 +224,7 @@ def confusion_matrix_holdout(on_run=True, on_fold=True, on_repetition=True, on_e
             _confusion_matrix(data_holdout.target.fold, data_holdout.prediction.fold)
         )
 
-    def _on_repetition_end(stat_aggregates, data_holdout):
+    def _on_rep_end(stat_aggregates, data_holdout):
         """Callback to execute upon ending an Experiment's repetition. Note that parameters are
         named after Experiment attributes
 
@@ -239,7 +239,7 @@ def confusion_matrix_holdout(on_run=True, on_fold=True, on_repetition=True, on_e
             _confusion_matrix(data_holdout.target.d, data_holdout.prediction.rep)  # FLAG: TEMPORARY
         )
 
-    def _on_experiment_end(stat_aggregates, data_holdout):
+    def _on_exp_end(stat_aggregates, data_holdout):
         """Callback to execute upon ending an Experiment. Note that parameters are
         named after Experiment attributes
 
@@ -256,11 +256,11 @@ def confusion_matrix_holdout(on_run=True, on_fold=True, on_repetition=True, on_e
         )
 
     return lambda_callback(
-        on_experiment_start=_on_experiment_start,
+        on_exp_start=_on_exp_start,
         on_run_end=_on_run_end if on_run else None,
         on_fold_end=_on_fold_end if on_fold else None,
-        on_repetition_end=_on_repetition_end if on_repetition else None,
-        on_experiment_end=_on_experiment_end if on_experiment else None,
+        on_rep_end=_on_rep_end if on_rep else None,
+        on_exp_end=_on_exp_end if on_exp else None,
         agg_name="confusion_matrix_holdout",
     )
 
@@ -309,14 +309,14 @@ def dataset_recorder():
 
 
 def lambda_check_train_targets(
-    on_experiment_start: Optional[List[TrainTargetChunk]] = None,
-    on_repetition_start: Optional[List[TrainTargetChunk]] = None,
+    on_exp_start: Optional[List[TrainTargetChunk]] = None,
+    on_rep_start: Optional[List[TrainTargetChunk]] = None,
     on_fold_start: Optional[List[TrainTargetChunk]] = None,
     on_run_start: Optional[List[TrainTargetChunk]] = None,
     on_run_end: Optional[List[TrainTargetChunk]] = None,
     on_fold_end: Optional[List[TrainTargetChunk]] = None,
-    on_repetition_end: Optional[List[TrainTargetChunk]] = None,
-    on_experiment_end: Optional[List[TrainTargetChunk]] = None,
+    on_rep_end: Optional[List[TrainTargetChunk]] = None,
+    on_exp_end: Optional[List[TrainTargetChunk]] = None,
 ):
     """LambdaCallback to check the values of an experiment's `data_train.target` attribute
 
@@ -326,19 +326,19 @@ def lambda_check_train_targets(
     particular callback method. In other words, the number of items in each parameter's list should
     correspond to the number of times that callback method is expected to be invoked.
 
-    This means that `on_experiment_start` and `on_experiment_end` should both contain only a single
+    This means that `on_exp_start` and `on_exp_end` should both contain only a single
     `TrainTargetChunk` (because they are only ever invoked once by an experiment), and their values
     should be the expected states of `data_train.target` on experiment start and end, respectively.
 
     Parameters
     ----------
-    on_experiment_start: List[TrainTargetChunk], or None, default=None
-        Expected value of train targets when `on_experiment_start` is invoked. Should contain only
-        a single `TrainTargetChunk` instance
-    on_repetition_start: List[TrainTargetChunk], or None, default=None
-        Expected value of train targets on each invocation of `on_repetition_start`. Should contain
-        as many `TrainTargetChunk` instances as repetitions will be conducted during the experiment.
-        Should contain only a single value if the number or repetitions is one, or if
+    on_exp_start: List[TrainTargetChunk], or None, default=None
+        Expected value of train targets when `on_exp_start` is invoked. Should contain only a single
+        `TrainTargetChunk` instance
+    on_rep_start: List[TrainTargetChunk], or None, default=None
+        Expected value of train targets on each invocation of `on_rep_start`. Should contain as many
+        `TrainTargetChunk` instances as repetitions will be conducted during the experiment. Should
+        contain only a single value if the number or repetitions is one, or if
         :attr:`hyperparameter_hunter.environment.Environment.cv_type` is not a repeated CV scheme
     on_fold_start: List[TrainTargetChunk], or None, default=None
         Expected value of train targets on each invocation of `on_fold_start`. The values to
@@ -362,10 +362,10 @@ def lambda_check_train_targets(
         *See `on_run_start` description*
     on_fold_end: List[TrainTargetChunk], or None, default=None
         *See `on_fold_start` description*
-    on_repetition_end: List[TrainTargetChunk], or None, default=None
-        *See `on_repetition_start` description*
-    on_experiment_end: List[TrainTargetChunk], or None, default=None
-        *See `on_experiment_start` description*
+    on_rep_end: List[TrainTargetChunk], or None, default=None
+        *See `on_rep_start` description*
+    on_exp_end: List[TrainTargetChunk], or None, default=None
+        *See `on_exp_start` description*
 
     Notes
     -----
@@ -373,21 +373,21 @@ def lambda_check_train_targets(
     :attr:`hyperparameter_hunter.environment.Environment.runs` is 1. In this case, they will be
     invoked as many times as `on_fold_start` and `on_fold_end` are invoked; however, this does not
     mean that the values of `data_train.target` are identical between fold and run divisions"""
-    on_experiment_start = on_experiment_start if on_experiment_start is not None else []
-    on_repetition_start = on_repetition_start if on_repetition_start is not None else []
+    on_exp_start = on_exp_start if on_exp_start is not None else []
+    on_rep_start = on_rep_start if on_rep_start is not None else []
     on_fold_start = on_fold_start if on_fold_start is not None else []
     on_run_start = on_run_start if on_run_start is not None else []
     on_run_end = on_run_end if on_run_end is not None else []
     on_fold_end = on_fold_end if on_fold_end is not None else []
-    on_repetition_end = on_repetition_end if on_repetition_end is not None else []
-    on_experiment_end = on_experiment_end if on_experiment_end is not None else []
+    on_rep_end = on_rep_end if on_rep_end is not None else []
+    on_exp_end = on_exp_end if on_exp_end is not None else []
 
     #################### Division Start Points ####################
-    def _on_experiment_start(data_train):
-        assert data_train.target == on_experiment_start[0]
+    def _on_exp_start(data_train):
+        assert data_train.target == on_exp_start[0]
 
-    def _on_repetition_start(data_train, _rep):
-        assert data_train.target == on_repetition_start[_rep]
+    def _on_rep_start(data_train, _rep):
+        assert data_train.target == on_rep_start[_rep]
 
     def _on_fold_start(data_train, _rep, _fold):
         assert data_train.target == on_fold_start[((_rep + 1) * (_fold + 1) - 1)]
@@ -402,21 +402,21 @@ def lambda_check_train_targets(
     def _on_fold_end(data_train, _rep, _fold):
         assert data_train.target == on_fold_end[((_rep + 1) * (_fold + 1) - 1)]
 
-    def _on_repetition_end(data_train, _rep):
-        assert data_train.target == on_repetition_end[_rep]
+    def _on_rep_end(data_train, _rep):
+        assert data_train.target == on_rep_end[_rep]
 
-    def _on_experiment_end(data_train):
-        assert data_train.target == on_experiment_end[0]
+    def _on_exp_end(data_train):
+        assert data_train.target == on_exp_end[0]
 
     return lambda_callback(
-        on_experiment_start=_on_experiment_start if on_experiment_start else None,
-        on_repetition_start=_on_repetition_start if on_repetition_start else None,
+        on_exp_start=_on_exp_start if on_exp_start else None,
+        on_rep_start=_on_rep_start if on_rep_start else None,
         on_fold_start=_on_fold_start if on_fold_start else None,
         on_run_start=_on_run_start if on_run_start else None,
         on_run_end=_on_run_end if on_run_end else None,
         on_fold_end=_on_fold_end if on_fold_end else None,
-        on_repetition_end=_on_repetition_end if on_repetition_end else None,
-        on_experiment_end=_on_experiment_end if on_experiment_end else None,
+        on_rep_end=_on_rep_end if on_rep_end else None,
+        on_exp_end=_on_exp_end if on_exp_end else None,
     )
 
 
@@ -425,7 +425,7 @@ def lambda_check_train_targets(
 ##################################################
 # TODO: Add callback recipe to save an Experiment's description file as a yaml file alongside json
 # TODO: May need to extend `lambda_callback`'s capabilities to include the result-saving stage
-# TODO: ... The final description file likely isn't available at the time `on_experiment_end` called
+# TODO: ... The final description file likely isn't available at the time `on_exp_end` called
 # FLAG: When done, move this section below the "Confusion Matrix Callbacks" section below
 # FLAG: Consider adding option to save Experiment descriptions as yaml by default
 # FLAG: ... Will probably need to employ special `--- !!omap` yaml tags (http://yaml.org/spec/1.1/ ["Example 2.26"])
@@ -433,7 +433,7 @@ def lambda_check_train_targets(
 ##################################################
 # Keras Epochs Elapsed Callback
 ##################################################
-def aggregator_epochs_elapsed(on_run=True, on_fold=True, on_repetition=True, on_experiment=True):
+def aggregator_epochs_elapsed(on_run=True, on_fold=True, on_rep=True, on_exp=True):
     """Callback function to aggregate and average the number of epochs elapsed during model training
     at each stage of the Experiment
 
@@ -443,9 +443,9 @@ def aggregator_epochs_elapsed(on_run=True, on_fold=True, on_repetition=True, on_
         If False, skip recording epochs elapsed for individual Experiment runs
     on_fold: Boolean, default=True
         If False, skip making epochs-elapsed averages for individual Experiment folds
-    on_repetition: Boolean, default=True
+    on_rep: Boolean, default=True
         If False, skip making epochs-elapsed averages for individual Experiment repetitions
-    on_experiment: Boolean, default=True
+    on_exp: Boolean, default=True
         If False, skip making epochs-elapsed average for the Experiment
 
     Returns
@@ -465,14 +465,14 @@ def aggregator_epochs_elapsed(on_run=True, on_fold=True, on_repetition=True, on_
         if len(run_results) > 0:
             return np.average(run_results[-_run:])
 
-    def _on_repetition_end(stat_aggregates, _run, _fold):
+    def _on_rep_end(stat_aggregates, _run, _fold):
         """Average the number of epochs elapsed across all runs in the repetition"""
         run_results = stat_aggregates["_epochs_elapsed"]["runs"]
         if len(run_results) > 0:
             num_runs = _run * _fold
             return np.average(run_results[-num_runs:])
 
-    def _on_experiment_end(stat_aggregates, _run, _fold, _rep):
+    def _on_exp_end(stat_aggregates, _run, _fold, _rep):
         """Average the number of epochs elapsed across all runs in the Experiment"""
         run_results = stat_aggregates["_epochs_elapsed"]["runs"]
         if len(run_results) > 0:
@@ -482,7 +482,7 @@ def aggregator_epochs_elapsed(on_run=True, on_fold=True, on_repetition=True, on_
     return lambda_callback(
         on_run_end=_on_run_end if on_run else None,
         on_fold_end=_on_fold_end if on_fold else None,
-        on_repetition_end=_on_repetition_end if on_repetition else None,
-        on_experiment_end=_on_experiment_end if on_experiment else None,
+        on_rep_end=_on_rep_end if on_rep else None,
+        on_exp_end=_on_exp_end if on_exp else None,
         agg_name="epochs_elapsed",
     )

--- a/hyperparameter_hunter/callbacks/wranglers/input_wranglers.py
+++ b/hyperparameter_hunter/callbacks/wranglers/input_wranglers.py
@@ -30,9 +30,9 @@ from hyperparameter_hunter.data import TrainDataset, OOFDataset, HoldoutDataset,
 class WranglerInputTrain(BaseInputWranglerCallback):
     data_train: TrainDataset
 
-    def on_experiment_start(self):
-        self.data_train.input.on_experiment_start()
-        super().on_experiment_start()
+    def on_exp_start(self):
+        self.data_train.input.on_exp_start()
+        super().on_exp_start()
 
     def on_fold_start(self):
         self.data_train.input.on_fold_start()
@@ -42,9 +42,9 @@ class WranglerInputTrain(BaseInputWranglerCallback):
 class WranglerInputOOF(BaseInputWranglerCallback):
     data_oof: OOFDataset
 
-    def on_experiment_start(self):
-        self.data_oof.input.on_experiment_start()
-        super().on_experiment_start()
+    def on_exp_start(self):
+        self.data_oof.input.on_exp_start()
+        super().on_exp_start()
 
     def on_fold_start(self):
         self.data_oof.input.on_fold_start()
@@ -58,9 +58,9 @@ class WranglerInputHoldout(BaseInputWranglerCallback):
 
     data_holdout: HoldoutDataset
 
-    def on_experiment_start(self):
-        self.data_holdout.input.on_experiment_start()
-        super().on_experiment_start()
+    def on_exp_start(self):
+        self.data_holdout.input.on_exp_start()
+        super().on_exp_start()
 
     def on_fold_start(self):
         self.data_holdout.input.on_fold_start()
@@ -70,9 +70,9 @@ class WranglerInputHoldout(BaseInputWranglerCallback):
 class WranglerInputTest(BaseInputWranglerCallback):
     data_test: TestDataset
 
-    def on_experiment_start(self):
-        self.data_test.input.on_experiment_start()
-        super().on_experiment_start()
+    def on_exp_start(self):
+        self.data_test.input.on_exp_start()
+        super().on_exp_start()
 
     def on_fold_start(self):
         self.data_test.input.on_fold_start()

--- a/hyperparameter_hunter/callbacks/wranglers/predictors.py
+++ b/hyperparameter_hunter/callbacks/wranglers/predictors.py
@@ -47,13 +47,13 @@ class PredictorOOF(BasePredictorCallback):
     data_oof: OOFDataset
 
     #################### Division Start Points ####################
-    def on_experiment_start(self):
-        self.data_oof.prediction.on_experiment_start(self._empty_output_like(self.train_dataset))
-        super().on_experiment_start()
+    def on_exp_start(self):
+        self.data_oof.prediction.on_exp_start(self._empty_output_like(self.train_dataset))
+        super().on_exp_start()
 
-    def on_repetition_start(self):
-        self.data_oof.prediction.on_repetition_start(self._empty_output_like(self.train_dataset))
-        super().on_repetition_start()
+    def on_rep_start(self):
+        self.data_oof.prediction.on_rep_start(self._empty_output_like(self.train_dataset))
+        super().on_rep_start()
 
     def on_fold_start(self):  # Nothing
         self.data_oof.prediction.on_fold_start()
@@ -75,26 +75,26 @@ class PredictorOOF(BasePredictorCallback):
         self.data_oof.prediction.on_fold_end(self.validation_index, self.experiment_params["runs"])
         super().on_fold_end()
 
-    def on_repetition_end(self):
-        self.data_oof.prediction.on_repetition_end()
-        super().on_repetition_end()
+    def on_rep_end(self):
+        self.data_oof.prediction.on_rep_end()
+        super().on_rep_end()
 
-    def on_experiment_end(self):
-        self.data_oof.prediction.on_experiment_end(self.cv_params.get("n_repeats", 1))
-        super().on_experiment_end()
+    def on_exp_end(self):
+        self.data_oof.prediction.on_exp_end(self.cv_params.get("n_repeats", 1))
+        super().on_exp_end()
 
 
 class PredictorHoldout(BasePredictorCallback):
     data_holdout: HoldoutDataset
 
     #################### Division Start Points ####################
-    def on_experiment_start(self):
-        self.data_holdout.prediction.on_experiment_start()
-        super().on_experiment_start()
+    def on_exp_start(self):
+        self.data_holdout.prediction.on_exp_start()
+        super().on_exp_start()
 
-    def on_repetition_start(self):
-        self.data_holdout.prediction.on_repetition_start()
-        super().on_repetition_start()
+    def on_rep_start(self):
+        self.data_holdout.prediction.on_rep_start()
+        super().on_rep_start()
 
     def on_fold_start(self):
         self.data_holdout.prediction.on_fold_start()
@@ -116,26 +116,26 @@ class PredictorHoldout(BasePredictorCallback):
         self.data_holdout.prediction.on_fold_end(self.experiment_params["runs"])
         super().on_fold_end()
 
-    def on_repetition_end(self):
-        self.data_holdout.prediction.on_repetition_end(self.cv_params["n_splits"])
-        super().on_repetition_end()
+    def on_rep_end(self):
+        self.data_holdout.prediction.on_rep_end(self.cv_params["n_splits"])
+        super().on_rep_end()
 
-    def on_experiment_end(self):
-        self.data_holdout.prediction.on_experiment_end(self.cv_params.get("n_repeats", 1))
-        super().on_experiment_end()
+    def on_exp_end(self):
+        self.data_holdout.prediction.on_exp_end(self.cv_params.get("n_repeats", 1))
+        super().on_exp_end()
 
 
 class PredictorTest(BasePredictorCallback):
     data_test: TestDataset
 
     #################### Division Start Points ####################
-    def on_experiment_start(self):
-        self.data_test.prediction.on_experiment_start()
-        super().on_experiment_start()
+    def on_exp_start(self):
+        self.data_test.prediction.on_exp_start()
+        super().on_exp_start()
 
-    def on_repetition_start(self):
-        self.data_test.prediction.on_repetition_start()
-        super().on_repetition_start()
+    def on_rep_start(self):
+        self.data_test.prediction.on_rep_start()
+        super().on_rep_start()
 
     def on_fold_start(self):
         self.data_test.prediction.on_fold_start()
@@ -155,10 +155,10 @@ class PredictorTest(BasePredictorCallback):
         self.data_test.prediction.on_fold_end(self.experiment_params["runs"])
         super().on_fold_end()
 
-    def on_repetition_end(self):
-        self.data_test.prediction.on_repetition_end(self.cv_params["n_splits"])
-        super().on_repetition_end()
+    def on_rep_end(self):
+        self.data_test.prediction.on_rep_end(self.cv_params["n_splits"])
+        super().on_rep_end()
 
-    def on_experiment_end(self):
-        self.data_test.prediction.on_experiment_end(self.cv_params.get("n_repeats", 1))
-        super().on_experiment_end()
+    def on_exp_end(self):
+        self.data_test.prediction.on_exp_end(self.cv_params.get("n_repeats", 1))
+        super().on_exp_end()

--- a/hyperparameter_hunter/callbacks/wranglers/target_wranglers.py
+++ b/hyperparameter_hunter/callbacks/wranglers/target_wranglers.py
@@ -35,18 +35,14 @@ class WranglerTargetOOF(BaseTargetWranglerCallback):
     data_oof: OOFDataset
 
     #################### Division Start Points ####################
-    def on_experiment_start(self):
+    def on_exp_start(self):
         # NOTE: Mirror train targets index, but drop columns because they might change intra-CV
-        self.data_oof.target.on_experiment_start(
-            self._empty_output_like(self.data_train.target.T.d)
-        )
-        super().on_experiment_start()
+        self.data_oof.target.on_exp_start(self._empty_output_like(self.data_train.target.T.d))
+        super().on_exp_start()
 
-    def on_repetition_start(self):
-        self.data_oof.target.on_repetition_start(
-            self._empty_output_like(self.data_train.target.T.d)
-        )
-        super().on_repetition_start()
+    def on_rep_start(self):
+        self.data_oof.target.on_rep_start(self._empty_output_like(self.data_train.target.T.d))
+        super().on_rep_start()
 
     def on_fold_start(self):
         self.data_oof.target.on_fold_start()
@@ -65,30 +61,26 @@ class WranglerTargetOOF(BaseTargetWranglerCallback):
         self.data_oof.target.on_fold_end(self.validation_index)
         super().on_fold_end()
 
-    def on_repetition_end(self):
-        self.data_oof.target.on_repetition_end(self.cv_params["n_splits"])
-        super().on_repetition_end()
+    def on_rep_end(self):
+        self.data_oof.target.on_rep_end(self.cv_params["n_splits"])
+        super().on_rep_end()
 
-    def on_experiment_end(self):
-        self.data_oof.target.on_experiment_end(self.cv_params.get("n_repeats", 1))
-        super().on_experiment_end()
+    def on_exp_end(self):
+        self.data_oof.target.on_exp_end(self.cv_params.get("n_repeats", 1))
+        super().on_exp_end()
 
 
 class WranglerTargetHoldout(BaseTargetWranglerCallback):
     data_holdout: HoldoutDataset
 
     #################### Division Start Points ####################
-    def on_experiment_start(self):
-        self.data_holdout.target.on_experiment_start(
-            self._empty_output_like(self.data_holdout.target.T.d)
-        )
-        super().on_experiment_start()
+    def on_exp_start(self):
+        self.data_holdout.target.on_exp_start(self._empty_output_like(self.data_holdout.target.T.d))
+        super().on_exp_start()
 
-    def on_repetition_start(self):
-        self.data_holdout.target.on_repetition_start(
-            self._empty_output_like(self.data_holdout.target.T.d)
-        )
-        super().on_repetition_start()
+    def on_rep_start(self):
+        self.data_holdout.target.on_rep_start(self._empty_output_like(self.data_holdout.target.T.d))
+        super().on_rep_start()
 
     def on_fold_start(self):
         self.data_holdout.target.on_fold_start()
@@ -107,10 +99,10 @@ class WranglerTargetHoldout(BaseTargetWranglerCallback):
         self.data_holdout.target.on_fold_end()
         super().on_fold_end()
 
-    def on_repetition_end(self):
-        self.data_holdout.target.on_repetition_end(self.cv_params["n_splits"])
-        super().on_repetition_end()
+    def on_rep_end(self):
+        self.data_holdout.target.on_rep_end(self.cv_params["n_splits"])
+        super().on_rep_end()
 
-    def on_experiment_end(self):
-        self.data_holdout.target.on_experiment_end(self.cv_params.get("n_repeats", 1))
-        super().on_experiment_end()
+    def on_exp_end(self):
+        self.data_holdout.target.on_exp_end(self.cv_params.get("n_repeats", 1))
+        super().on_exp_end()

--- a/hyperparameter_hunter/data/data_chunks/prediction_chunks.py
+++ b/hyperparameter_hunter/data/data_chunks/prediction_chunks.py
@@ -18,11 +18,11 @@ import pandas as pd
 ##################################################
 class BasePredictionChunk(BaseDataChunk):
     #################### Division Start Points ####################
-    def on_experiment_start(self, *args, **kwargs):
+    def on_exp_start(self, *args, **kwargs):
         self.final = 0
         self.T.final = 0
 
-    def on_repetition_start(self, *args, **kwargs):
+    def on_rep_start(self, *args, **kwargs):
         self.rep = 0
         self.T.rep = 0
 
@@ -71,24 +71,24 @@ class BasePredictionChunk(BaseDataChunk):
         self.T.fold /= runs
         self.T.rep += self.T.fold
 
-    def on_repetition_end(self, n_splits: int, *args, **kwargs):
+    def on_rep_end(self, n_splits: int, *args, **kwargs):
         self.rep /= n_splits
         self.final += self.rep
         self.T.rep /= n_splits
         self.T.final += self.T.rep
 
-    def on_experiment_end(self, n_repeats: int):
+    def on_exp_end(self, n_repeats: int):
         self.final /= n_repeats
         self.T.final /= n_repeats
 
 
 class OOFPredictionChunk(BasePredictionChunk):
     #################### Division Start Points ####################
-    def on_experiment_start(self, zero_predictions, *args, **kwargs):
+    def on_exp_start(self, zero_predictions, *args, **kwargs):
         self.final = deepcopy(zero_predictions)
         self.T.final = deepcopy(zero_predictions)
 
-    def on_repetition_start(self, zero_predictions, *args, **kwargs):
+    def on_rep_start(self, zero_predictions, *args, **kwargs):
         self.rep = deepcopy(zero_predictions)
         self.T.rep = deepcopy(zero_predictions)
 
@@ -100,7 +100,7 @@ class OOFPredictionChunk(BasePredictionChunk):
         self.T.fold /= runs
         self.T.rep.iloc[validation_index] += self.T.fold.values
 
-    def on_repetition_end(self, *args, **kwargs):
+    def on_rep_end(self, *args, **kwargs):
         self.final += self.rep
         self.T.final += self.T.rep
 

--- a/hyperparameter_hunter/data/data_chunks/target_chunks.py
+++ b/hyperparameter_hunter/data/data_chunks/target_chunks.py
@@ -24,10 +24,10 @@ class TrainTargetChunk(BaseTargetChunk):
 
 class OOFTargetChunk(BaseTargetChunk):
     #################### Division Start Points ####################
-    def on_experiment_start(self, empty_output_frame, *args, **kwargs):
+    def on_exp_start(self, empty_output_frame, *args, **kwargs):
         self.T.final = empty_output_frame
 
-    def on_repetition_start(self, empty_output_frame, *args, **kwargs):
+    def on_rep_start(self, empty_output_frame, *args, **kwargs):
         self.T.rep = empty_output_frame
 
     def on_fold_start(self, *args, **kwargs):
@@ -43,20 +43,20 @@ class OOFTargetChunk(BaseTargetChunk):
     def on_fold_end(self, validation_index, *args, **kwargs):
         self.T.rep.iloc[validation_index] += self.T.fold
 
-    def on_repetition_end(self, n_splits: int, *args, **kwargs):
+    def on_rep_end(self, n_splits: int, *args, **kwargs):
         self.T.final += self.T.rep
 
-    def on_experiment_end(self, n_repeats: int, *args, **kwargs):
+    def on_exp_end(self, n_repeats: int, *args, **kwargs):
         self.T.final /= n_repeats
 
 
 class HoldoutTargetChunk(BaseTargetChunk):
     #################### Division Start Points ####################
-    def on_experiment_start(self, empty_output_frame, *args, **kwargs):
-        # `self.d` and `self.T.d` (pre-CV) set by `BaseExperiment.on_experiment_start`
+    def on_exp_start(self, empty_output_frame, *args, **kwargs):
+        # `self.d` and `self.T.d` (pre-CV) set by `BaseExperiment.on_exp_start`
         self.T.final = empty_output_frame
 
-    def on_repetition_start(self, empty_output_frame, *args, **kwargs):
+    def on_rep_start(self, empty_output_frame, *args, **kwargs):
         self.T.rep = empty_output_frame
 
     def on_fold_start(self, *args, **kwargs):
@@ -72,9 +72,9 @@ class HoldoutTargetChunk(BaseTargetChunk):
     def on_fold_end(self, *args, **kwargs):
         self.T.rep += self.T.fold
 
-    def on_repetition_end(self, n_splits: int, *args, **kwargs):
+    def on_rep_end(self, n_splits: int, *args, **kwargs):
         self.T.rep /= n_splits
         self.T.final += self.T.rep
 
-    def on_experiment_end(self, n_repeats: int, *args, **kwargs):
+    def on_exp_end(self, n_repeats: int, *args, **kwargs):
         self.T.final /= n_repeats

--- a/hyperparameter_hunter/data/data_core.py
+++ b/hyperparameter_hunter/data/data_core.py
@@ -89,11 +89,11 @@ class BaseDataCore:
         * :meth:`BaseDataCore._do_something` calls the appropriate core callback method"""
 
     #################### Primary Callback Methods ####################
-    def on_experiment_start(self, *args, **kwargs):
-        self._on_call_default("experiment", "start", *args, **kwargs)
+    def on_exp_start(self, *args, **kwargs):
+        self._on_call_default("exp", "start", *args, **kwargs)
 
-    def on_repetition_start(self, *args, **kwargs):
-        self._on_call_default("repetition", "start", *args, **kwargs)
+    def on_rep_start(self, *args, **kwargs):
+        self._on_call_default("rep", "start", *args, **kwargs)
 
     def on_fold_start(self, *args, **kwargs):
         self._on_call_default("fold", "start", *args, **kwargs)
@@ -107,11 +107,11 @@ class BaseDataCore:
     def on_fold_end(self, *args, **kwargs):
         self._on_call_default("fold", "end", *args, **kwargs)
 
-    def on_repetition_end(self, *args, **kwargs):
-        self._on_call_default("repetition", "end", *args, **kwargs)
+    def on_rep_end(self, *args, **kwargs):
+        self._on_call_default("rep", "end", *args, **kwargs)
 
-    def on_experiment_end(self, *args, **kwargs):
-        self._on_call_default("experiment", "end", *args, **kwargs)
+    def on_exp_end(self, *args, **kwargs):
+        self._on_call_default("exp", "end", *args, **kwargs)
 
     #################### Internal Methods ####################
     def _on_call_default(self, division: str, point: str, *args, **kwargs):
@@ -119,7 +119,7 @@ class BaseDataCore:
 
         Parameters
         ----------
-        division: {"experiment", "repetition", "fold", "run"}
+        division: {"exp", "rep", "fold", "run"}
             Time span division identifier of the primary callback method to be invoked
         point: {"start", "end"}
             Time span point identifier in `division` of the primary callback method to be invoked
@@ -144,7 +144,7 @@ class BaseDataCore:
 
         Parameters
         ----------
-        division: {"experiment", "repetition", "fold", "run"}
+        division: {"exp", "rep", "fold", "run"}
             Time span division identifier of the primary callback method to be invoked
         point: {"start", "end"}
             Time span point identifier in `division` of the primary callback method to be invoked

--- a/hyperparameter_hunter/experiments.py
+++ b/hyperparameter_hunter/experiments.py
@@ -21,7 +21,6 @@ on what's going on in :mod:`experiment_core`, and its related modules"""
 ##################################################
 # Import Own Assets
 ##################################################
-# noinspection PyProtectedMember
 from hyperparameter_hunter import __version__
 from hyperparameter_hunter.algorithm_handlers import (
     identify_algorithm,
@@ -41,8 +40,6 @@ from hyperparameter_hunter.models import model_selector
 from hyperparameter_hunter.recorders import RecorderList
 from hyperparameter_hunter.settings import G
 from hyperparameter_hunter.utils.file_utils import RetryMakeDirs
-
-# from hyperparameter_hunter.utils.general_utils import Deprecated
 
 ##################################################
 # Import Miscellaneous Assets

--- a/hyperparameter_hunter/experiments.py
+++ b/hyperparameter_hunter/experiments.py
@@ -41,7 +41,8 @@ from hyperparameter_hunter.models import model_selector
 from hyperparameter_hunter.recorders import RecorderList
 from hyperparameter_hunter.settings import G
 from hyperparameter_hunter.utils.file_utils import RetryMakeDirs
-from hyperparameter_hunter.utils.general_utils import Deprecated
+
+# from hyperparameter_hunter.utils.general_utils import Deprecated
 
 ##################################################
 # Import Miscellaneous Assets
@@ -259,7 +260,7 @@ class BaseExperiment(ScoringMixIn):
     ##################################################
     # Data Preprocessing Methods:
     ##################################################
-    def on_experiment_start(self):
+    def on_exp_start(self):
         """Prepare data prior to executing fitting protocol (cross-validation), by 1) Initializing
         formal :mod:`~hyperparameter_hunter.data.datasets` attributes, 2) Invoking
         `feature_engineer` to perform "pre_cv"-stage preprocessing, and 3) Updating datasets to
@@ -288,7 +289,7 @@ class BaseExperiment(ScoringMixIn):
         self.data_test.input.T.d = self.feature_engineer.datasets["test_inputs"]
 
         G.log("Initial preprocessing stage complete", 4)
-        super().on_experiment_start()
+        super().on_exp_start()
 
     ##################################################
     # Supporting Methods:
@@ -503,20 +504,20 @@ class BaseCVExperiment(BaseExperiment):
         1) Create train and validation split indices for all folds, 2) Iterate through folds,
         performing `cv_fold_workflow` for each, 3) Average accumulated predictions over fold
         splits, 4) Evaluate final predictions, 5) Format final predictions to prepare for saving"""
-        self.on_experiment_start()
+        self.on_exp_start()
 
         reshaped_indices = get_cv_indices(
             self.folds, self.cv_params, self.data_train.input.d, self.data_train.target.d.iloc[:, 0]
         )
 
         for self._rep, rep_indices in enumerate(reshaped_indices):
-            self.on_repetition_start()
+            self.on_rep_start()
 
             for self._fold, (self.train_index, self.validation_index) in enumerate(rep_indices):
                 self.cv_fold_workflow()
 
-            self.on_repetition_end()
-        self.on_experiment_end()
+            self.on_rep_end()
+        self.on_exp_end()
 
         G.log("")
 

--- a/hyperparameter_hunter/utils/general_utils.py
+++ b/hyperparameter_hunter/utils/general_utils.py
@@ -3,20 +3,16 @@ primarily small functions that perform oft-repeated tasks"""
 ##################################################
 # Import Own Assets
 ##################################################
-from hyperparameter_hunter.exceptions import DeprecatedWarning, UnsupportedWarning
 from hyperparameter_hunter.utils.boltons_utils import remap, default_enter
 
 ##################################################
 # Import Miscellaneous Assets
 ##################################################
 from datetime import datetime
-from functools import wraps
 from inspect import Traceback
 import re
 import string
-from textwrap import dedent
 from typing import Any, Callable, Iterable, List, Tuple, Union
-from warnings import warn, simplefilter
 import wrapt
 
 
@@ -237,195 +233,6 @@ def to_standard_string(a_string):
 def standard_equality(string_1, string_2):
     # assert (isinstance(string_1, str) and isinstance(string_2, str))
     return to_standard_string(string_1) == to_standard_string(string_2)
-
-
-##################################################
-# Deprecation Utilities
-##################################################
-# Below utilities adapted from the `deprecation` library: https://github.com/briancurtin/deprecation
-# Thank you to the creator and contributors of `deprecation` for their excellent work
-MESSAGE_LOCATION = "bottom"
-
-
-class Deprecated(object):
-    def __init__(self, v_deprecate=None, v_remove=None, v_current=None, details=""):
-        """Decorator to mark a function or class as deprecated. Issue warning when the function is
-        called or the class is instantiated, and add a warning to the docstring. The optional
-        `details` argument will be appended to the deprecation message and the docstring
-
-        Parameters
-        ----------
-        v_deprecate: String, default=None
-            Version in which the decorated callable is considered deprecated. This will usually
-            be the next version to be released when the decorator is added. If None, deprecation
-            will be immediate, and the `v_remove` and `v_current` arguments are ignored
-        v_remove: String, default=None
-            Version in which the decorated callable will be removed. If None, the callable is not
-            currently planned to be removed. Cannot be set if `v_deprecate` = None
-        v_current: String, default=None
-            Source of version information for currently running code. When `v_current` = None, the
-            ability to determine whether the wrapped callable is actually in a period of deprecation
-            or time for removal fails, raising a :class:`DeprecatedWarning` in all cases
-        details: String, default=""
-            Extra details added to callable docstring/warning, such as a suggested replacement"""
-        self.v_deprecate = v_deprecate
-        self.v_remove = v_remove
-        self.v_current = v_current
-        self.details = details
-
-        if self.v_deprecate is None and self.v_remove is not None:
-            raise TypeError("Cannot set `v_remove` without also setting `v_deprecate`")
-
-        #################### Determine Deprecation Status ####################
-        self.is_deprecated = False
-        self.is_unsupported = False
-
-        if self.v_current:
-            self.v_current = split_version(self.v_current)
-
-            if self.v_remove and self.v_current >= split_version(self.v_remove):
-                self.is_unsupported = True
-            elif self.v_deprecate and self.v_current >= split_version(self.v_deprecate):
-                self.is_deprecated = True
-        else:
-            self.is_deprecated = True
-
-        self.do_warn = any([self.is_deprecated, self.is_unsupported])
-        self.warning = None
-
-    def __call__(self, obj):
-        """Call method on callable `obj` to deprecate
-
-        Parameters
-        ----------
-        obj: Object
-            The callable being decorated as deprecated
-
-        Object
-            Callable result of either: 1) :meth:`_decorate_class` if `obj` is a class, or
-            2) :meth:`_decorate_function` if `obj` is a function/method"""
-        #################### Log Deprecation Warning ####################
-        if self.do_warn:
-            warn_cls = UnsupportedWarning if self.is_unsupported else DeprecatedWarning
-            self.warning = warn_cls(obj.__name__, self.v_deprecate, self.v_remove, self.details)
-            warn(self.warning, category=DeprecationWarning, stacklevel=2)
-
-        #################### Decorate and Return Callable ####################
-        if isinstance(obj, type):
-            return self._decorate_class(obj)
-        else:
-            return self._decorate_function(obj)
-
-    def _decorate_class(self, cls):
-        """Helper method to handle wrapping of class callables
-
-        Parameters
-        ----------
-        cls: Class
-            The class to be wrapped with a deprecation warning, and an updated docstring
-
-        Returns
-        -------
-        cls: Class
-            Updated `cls` that raises a deprecation warning before being called, and contains
-            an updated docstring"""
-        init = cls.__init__
-
-        def wrapped(*args, **kwargs):
-            self._verbose_warning()
-            return init(*args, **kwargs)
-
-        cls.__init__ = wrapped
-        wrapped.__name__ = "__init__"
-        wrapped.__doc__ = self._update_doc(init.__doc__)
-        wrapped.deprecated_original = init
-        return cls
-
-    def _decorate_function(self, f):
-        """Helper method to handle wrapping of function/method callables
-
-        Parameters
-        ----------
-        f: Function
-            The function to be wrapped with a deprecation warning, and an updated docstring
-
-        Returns
-        -------
-        wrapped: Function
-            Updated `f` that raises a deprecation warning before being called, and contains
-            an updated docstring"""
-
-        @wraps(f)
-        def wrapped(*args, **kwargs):
-            self._verbose_warning()
-            return f(*args, **kwargs)
-
-        wrapped.__doc__ = self._update_doc(wrapped.__doc__)
-        wrapped.__wrapped__ = f
-        return wrapped
-
-    def _update_doc(self, old_doc):
-        """Create a docstring containing the old docstring, in addition to a deprecation warning
-
-        Parameters
-        ----------
-        old_doc: String
-            Original docstring for the callable being deprecated, to which a warning will be added
-
-        Returns
-        -------
-        String
-            A new docstring with both the original docstring and a deprecation warning"""
-        if not self.do_warn:
-            return old_doc
-
-        old_doc = old_doc or ""
-
-        parts = dict(
-            v_deprecate=" {}".format(self.v_deprecate) if self.v_deprecate else "",
-            v_remove="\n   Will be removed in {}.".format(self.v_remove) if self.v_remove else "",
-            details=" {}".format(self.details) if self.details else "",
-        )
-
-        deprecation_note = ".. deprecated::{v_deprecate}{v_remove}{details}".format(**parts)
-        loc = 1
-        string_list = old_doc.split("\n", 1)
-
-        if len(string_list) > 1:
-            string_list[1] = dedent(string_list[1])
-            string_list.insert(loc, "\n")
-
-            if MESSAGE_LOCATION != "top":
-                loc = 3
-
-        string_list.insert(loc, deprecation_note)
-        string_list.insert(loc, "\n\n")
-
-        return "".join(string_list)
-
-    def _verbose_warning(self):
-        """Issue :attr:`warning`, bypassing the standard filter that silences DeprecationWarnings"""
-        if self.do_warn:
-            simplefilter("always", DeprecatedWarning)
-            simplefilter("always", UnsupportedWarning)
-            warn(self.warning, category=DeprecationWarning, stacklevel=4)
-            simplefilter("default", DeprecatedWarning)
-            simplefilter("default", UnsupportedWarning)
-
-
-def split_version(s: str):
-    """Split a version string into a tuple of integers to facilitate comparison
-
-    Parameters
-    ----------
-    s: String
-        Version string containing integers separated by periods
-
-    Returns
-    -------
-    Tuple
-        The integer values from `s`, separated by periods"""
-    return tuple([int(_) for _ in s.split(".")])
 
 
 class Alias:

--- a/tests/integration_tests/feature_engineering/test_pre_cv.py
+++ b/tests/integration_tests/feature_engineering/test_pre_cv.py
@@ -262,16 +262,16 @@ def prepped_experiment(request):
 
     1. :meth:`~hyperparameter_hunter.experiments.BaseExperiment.preparation_workflow`,
     2. :meth:`~hyperparameter_hunter.experiments.BaseExperiment._initialize_random_seeds`, and
-    3. :meth:`~hyperparameter_hunter.experiments.BaseExperiment.on_experiment_start`, which
-       initializes the four :mod:`~hyperparameter_hunter.data.datasets` classes, then performs
-       pre-CV feature engineering
+    3. :meth:`~hyperparameter_hunter.experiments.BaseExperiment.on_exp_start`, which initializes the
+       four :mod:`~hyperparameter_hunter.data.datasets` classes, then performs pre-CV feature
+       engineering
 
     Notes
     -----
-    Directly calling `on_experiment_start` is ok in this test because after calling
+    Directly calling `on_exp_start` is ok in this test because after calling
     `_initialize_random_seeds`, `BaseExperiment` calls `execute`, which is implemented by
     `BaseCVExperiment`, and only calls `cross_validation_workflow`, whose first task is to call
-    `on_experiment_start`. So nothing gets skipped in between"""
+    `on_exp_start`. So nothing gets skipped in between"""
     #################### Build `feature_engineer` ####################
     feature_engineer = FeatureEngineer(steps=request.param)
 
@@ -285,7 +285,7 @@ def prepped_experiment(request):
     experiment.preparation_workflow()
     # noinspection PyProtectedMember
     experiment._initialize_random_seeds()
-    experiment.on_experiment_start()
+    experiment.on_exp_start()
 
     return experiment
 

--- a/tests/smoke_tests/test_general.py
+++ b/tests/smoke_tests/test_general.py
@@ -85,10 +85,10 @@ def env_3():
             print(f"{_rep}.{_fold}.{_run}   {last_evaluation_results}")
 
         return lambda_callback(
-            on_experiment_start=printer_helper,
-            on_experiment_end=printer_helper,
-            on_repetition_start=printer_helper,
-            on_repetition_end=printer_helper,
+            on_exp_start=printer_helper,
+            on_exp_end=printer_helper,
+            on_rep_start=printer_helper,
+            on_rep_end=printer_helper,
             on_fold_start=printer_helper,
             on_fold_end=printer_helper,
             on_run_start=printer_helper,

--- a/tests/test_callbacks/test_bases.py
+++ b/tests/test_callbacks/test_bases.py
@@ -1,0 +1,49 @@
+##################################################
+# Import Own Assets
+##################################################
+from hyperparameter_hunter.callbacks.bases import lambda_callback
+
+##################################################
+# Import Miscellaneous Assets
+##################################################
+from copy import deepcopy
+import pytest
+
+
+def printer_helper(_rep, _fold, _run, last_evaluation_results):
+    print(f"{_rep}.{_fold}.{_run}   {last_evaluation_results}")
+
+
+good_lambda_callback_kwargs = dict(
+    on_exp_start=printer_helper,
+    on_rep_start=printer_helper,
+    on_fold_start=printer_helper,
+    on_run_start=printer_helper,
+    on_run_end=printer_helper,
+    on_fold_end=printer_helper,
+    on_rep_end=printer_helper,
+    on_exp_end=printer_helper,
+)
+
+
+@pytest.mark.parametrize(
+    ["add_kwarg", "drop_kwarg"],
+    [
+        ("on_experiment_start", "on_exp_start"),
+        ("on_experiment_end", "on_exp_end"),
+        ("on_repetition_start", "on_rep_start"),
+        ("on_repetition_end", "on_rep_end"),
+    ],
+)
+def test_lambda_callback_deprecations(add_kwarg, drop_kwarg):
+    """This function tests the deprecations of the following `lambda_callback` kwargs in 3.0.0:
+    * `on_experiment_start` -> `on_exp_start`
+    * `on_experiment_end` -> `on_exp_end`
+    * `on_repetition_start` -> `on_rep_start`
+    * `on_repetition_end` -> `on_rep_end`"""
+    bad_lambda_callback_kwargs = deepcopy(good_lambda_callback_kwargs)
+    del bad_lambda_callback_kwargs[drop_kwarg]
+    bad_lambda_callback_kwargs[add_kwarg] = printer_helper
+
+    with pytest.deprecated_call():
+        lambda_callback(**bad_lambda_callback_kwargs)

--- a/tests/test_callbacks/test_predictors.py
+++ b/tests/test_callbacks/test_predictors.py
@@ -44,14 +44,14 @@ class DummyExperimentPredictorHoldout(BaseCallback):
 
         self.__assert_prediction_is_none(["final", "rep", "fold", "run"])
 
-    def on_experiment_start(self):
-        super().on_experiment_start()
+    def on_exp_start(self):
+        super().on_exp_start()
 
         self.__assert_prediction_is_zero(["final"])
         self.__assert_prediction_is_none(["rep", "fold", "run"])
 
-    def on_repetition_start(self):
-        super().on_repetition_start()
+    def on_rep_start(self):
+        super().on_rep_start()
 
         self.__assert_about_prediction(["final"], lambda _: _ is not None)
         self.__assert_prediction_is_zero(["rep"])
@@ -86,11 +86,11 @@ class DummyExperimentPredictorHoldout(BaseCallback):
         assert self.data_holdout.prediction.fold.equals(expected_fold_prediction)
         assert self.data_holdout.prediction.rep.equals(expected_rep_prediction)
 
-    def on_repetition_end(self):
+    def on_rep_end(self):
         initial_rep_prediction = deepcopy(self.data_holdout.prediction.rep)
         initial_final_prediction = deepcopy(self.data_holdout.prediction.final)
 
-        super().on_repetition_end()
+        super().on_rep_end()
 
         self.__assert_prediction_is_df(["final", "rep", "fold", "run"])
         expected_rep_prediction = initial_rep_prediction / self.cv_params["n_splits"]
@@ -98,10 +98,10 @@ class DummyExperimentPredictorHoldout(BaseCallback):
         assert self.data_holdout.prediction.rep.equals(expected_rep_prediction)
         assert self.data_holdout.prediction.final.equals(expected_final_prediction)
 
-    def on_experiment_end(self):
+    def on_exp_end(self):
         initial_final_prediction = deepcopy(self.data_holdout.prediction.final)
 
-        super().on_experiment_end()
+        super().on_exp_end()
 
         self.__assert_prediction_is_df(["final", "rep", "fold", "run"])
         expected_final_prediction = initial_final_prediction / self.cv_params.get("n_repeats", 1)

--- a/tests/test_data/test_data_core.py
+++ b/tests/test_data/test_data_core.py
@@ -31,7 +31,7 @@ def base_dataset_fixture():
 ##################################################
 @mock.patch("hyperparameter_hunter.data.data_core.NullDataChunk._on_call_default")
 @pytest.mark.parametrize("point", ["start", "end"])
-@pytest.mark.parametrize("division", ["experiment", "repetition", "fold", "run"])
+@pytest.mark.parametrize("division", ["exp", "rep", "fold", "run"])
 def test_callback_method_invocation(mock_on_call_default, point, division, null_chunk_fixture):
     """Test that calling any primary callback methods of :class:`data.data_core.NullDataChunk`
     results in a call to :meth:`data.data_core.BaseDataCore._on_call_default` with the appropriate
@@ -42,7 +42,7 @@ def test_callback_method_invocation(mock_on_call_default, point, division, null_
 
 
 @pytest.mark.parametrize("point", ["start", "end"])
-@pytest.mark.parametrize("division", ["experiment", "repetition", "fold", "run"])
+@pytest.mark.parametrize("division", ["exp", "rep", "fold", "run"])
 def test_do_something_invocation(point, division, null_chunk_fixture):
     """Test that calling :meth:`data.data_core.NullDataChunk._do_something` results in the invocation
     of the proper primary callback method as specified by `division` and `point`. Using
@@ -57,7 +57,7 @@ def test_do_something_invocation(point, division, null_chunk_fixture):
 
 
 @pytest.mark.parametrize("point", ["start", "end"])
-@pytest.mark.parametrize("division", ["experiment", "repetition", "fold", "run"])
+@pytest.mark.parametrize("division", ["exp", "rep", "fold", "run"])
 def test_kind_chunk_invocation(point, division, base_dataset_fixture):
     """Test that calling :meth:`data.data_core.BaseDataset._do_something` results in the invocation
     of the proper callback method of :class:`data.data_core.BaseDataChunk` three times (once for


### PR DESCRIPTION
* `lambda_callback` kwargs dealing with "experiment" and "repetition" time steps have been 
   shortened
   * These four kwargs have been changed to the following values:
      * `on_experiment_start` -> `on_exp_start`
      * `on_experiment_end` -> `on_exp_end`
      * `on_repetition_start` -> `on_rep_start`
      * `on_repetition_end` -> `on_rep_end`
* Method names of all other internally-used callbacks have been changed accordingly