### PR TITLE
Tests for bug when using `BayesianOptPro` in exclusively-`Categorical` with `FeatureEngineer`

### DIFF
--- a/tests/integration_tests/feature_engineering/test_feature_optimization.py
+++ b/tests/integration_tests/feature_engineering/test_feature_optimization.py
@@ -20,7 +20,6 @@ import sys
 ##################################################
 # Import Learning Assets
 ##################################################
-from sklearn.datasets import load_boston
 from sklearn.ensemble import AdaBoostRegressor
 from sklearn.linear_model import Ridge
 from sklearn.model_selection import train_test_split
@@ -272,13 +271,6 @@ def test_not_in_target_space(space_item):
 ##################################################
 # Similar Experiment Description Scenarios
 ##################################################
-def get_boston_data():
-    data = load_boston()
-    df = pd.DataFrame(data=data.data, columns=data.feature_names)
-    df["median_value"] = data.target
-    return df
-
-
 # noinspection PyUnusedLocal
 def get_holdout_data(train, target_column):
     train_data, holdout_data = train_test_split(train, random_state=1)

--- a/tests/integration_tests/feature_engineering/test_saved_engineer_step.py
+++ b/tests/integration_tests/feature_engineering/test_saved_engineer_step.py
@@ -77,7 +77,7 @@ def env_boston():
 
 
 def opt_pro(optimization_protocol):
-    opt = optimization_protocol(iterations=11, random_state=32)
+    opt = optimization_protocol(iterations=3, random_state=32, n_initial_points=1)
     opt.set_experiment_guidelines(
         model_initializer=XGBRegressor,
         model_init_params=dict(
@@ -112,7 +112,7 @@ def test_saved_engineer_step_update_0(env_boston, protocol_0, protocol_1):
     exception, and it should never be a problem, so it makes sense to test it"""
     opt_0 = opt_pro(protocol_0)  # First Optimization Execution
     opt_1 = opt_pro(protocol_1)  # Second (Uninformed) Execution
-    assert len(opt_1.similar_experiments) == 11
+    assert len(opt_1.similar_experiments) == 3  # From `opt_pro`'s `iterations`
 
 
 @pytest.mark.xfail(condition="__version__ < '3.0.0alpha2'")

--- a/tests/integration_tests/test_optimization_space.py
+++ b/tests/integration_tests/test_optimization_space.py
@@ -1,0 +1,188 @@
+"""This module contains tests for specific combinations of dimensions and `OptimizationProtocol` s
+that have not integrated smoothly in the past. These tests are mostly concerned with
+`BayesianOptPro` and `Categorical` dimensions
+
+Related
+-------
+:mod:`tests.integration_tests.feature_engineering.test_feature_optimization`
+    This module defines regression tests for `BayesianOptPro` when given exclusively `Categorical`
+    spaces that include `FeatureEngineer`. The tests therein are closely related to these tests,
+    except `test_feature_optimization` is focused on `FeatureEngineer` in particular"""
+##################################################
+# Import Own Assets
+##################################################
+from hyperparameter_hunter import Environment, Real, Integer, Categorical
+from hyperparameter_hunter import BayesianOptPro, GBRT, RF, ET, DummyOptPro
+from hyperparameter_hunter.utils.learning_utils import get_breast_cancer_data
+
+##################################################
+# Import Miscellaneous Assets
+##################################################
+from os import makedirs
+import pytest
+from shutil import rmtree
+
+try:
+    keras = pytest.importorskip("keras")
+except Exception:
+    raise
+
+##################################################
+# Import Learning Assets
+##################################################
+from keras.layers import Dense, Dropout
+from keras.models import Sequential
+from keras.wrappers.scikit_learn import KerasClassifier
+
+##################################################
+# Global Settings
+##################################################
+assets_dir = "hyperparameter_hunter/__TEST__HyperparameterHunterAssets__"
+# assets_dir = "hyperparameter_hunter/HyperparameterHunterAssets"
+
+
+@pytest.fixture(scope="function", autouse=False)
+def hh_assets():
+    """Construct a temporary HyperparameterHunterAssets directory that exists only for the duration
+    of the tests contained in each function, before it and its contents are deleted"""
+    temp_assets_path = assets_dir
+    try:
+        makedirs(temp_assets_path)
+    except FileExistsError:
+        rmtree(temp_assets_path)
+        makedirs(temp_assets_path)
+    yield
+
+
+@pytest.fixture()
+def env_breast_cancer():
+    env = Environment(
+        train_dataset=get_breast_cancer_data(target="target"),
+        results_path=assets_dir,
+        metrics=["roc_auc_score"],
+        cv_type="StratifiedKFold",
+        cv_params=dict(n_splits=5, shuffle=True, random_state=32),
+    )
+    return env
+
+
+##################################################
+# Keras Optimization Tests
+##################################################
+def _build_tri_cat(input_shape):
+    model = Sequential(
+        [
+            Dense(90, input_shape=input_shape, activation=Categorical(["elu", "selu", "relu"])),
+            Dropout(0.5),
+            Dense(1, activation=Categorical(["elu", "softsign", "relu", "tanh", "sigmoid"])),
+        ]
+    )
+    model.compile(
+        optimizer=Categorical(["sgd", "rmsprop", "adagrad", "adadelta", "adam", "adamax", "nadam"]),
+        loss="binary_crossentropy",
+        metrics=["accuracy"],
+    )
+    return model
+
+
+def _build_tri_cat_real(input_shape):
+    model = Sequential(
+        [
+            Dense(90, input_shape=input_shape, activation=Categorical(["elu", "selu", "relu"])),
+            Dropout(Real(0.2, 0.7)),
+            Dense(1, activation=Categorical(["selu", "softsign", "relu", "tanh", "sigmoid"])),
+        ]
+    )
+    model.compile(
+        optimizer=Categorical(["adam", "rmsprop"]), loss="binary_crossentropy", metrics=["accuracy"]
+    )
+    return model
+
+
+def _build_penta_cat(input_shape):
+    model = Sequential(
+        [
+            Dense(
+                90,
+                kernel_initializer=Categorical(["lecun_uniform", "lecun_normal", "glorot_normal"]),
+                input_shape=input_shape,
+                activation=Categorical(["elu", "selu", "softsign", "relu", "tanh", "sigmoid"]),
+            ),
+            Dropout(0.5),
+            Dense(
+                1,
+                kernel_initializer=Categorical(["lecun_uniform", "lecun_normal", "glorot_normal"]),
+                activation=Categorical(["elu", "selu", "softsign", "relu", "tanh", "sigmoid"]),
+            ),
+        ]
+    )
+    model.compile(
+        optimizer=Categorical(["sgd", "rmsprop", "adagrad", "adadelta", "adam", "adamax", "nadam"]),
+        loss="binary_crossentropy",
+        metrics=["accuracy"],
+    )
+    return model
+
+
+def _build_penta_cat_int(input_shape):
+    model = Sequential(
+        [
+            Dense(
+                Integer(50, 100),
+                kernel_initializer=Categorical(["lecun_uniform", "lecun_normal", "glorot_normal"]),
+                input_shape=input_shape,
+                activation=Categorical(["elu", "selu", "softsign", "relu", "tanh", "sigmoid"]),
+            ),
+            Dropout(0.5),
+            Dense(
+                1,
+                kernel_initializer=Categorical(["lecun_uniform", "lecun_normal", "glorot_normal"]),
+                activation=Categorical(["elu", "selu", "softsign", "relu", "tanh", "sigmoid"]),
+            ),
+        ]
+    )
+    model.compile(
+        optimizer=Categorical(["sgd", "rmsprop", "adagrad", "adadelta", "adam", "adamax", "nadam"]),
+        loss="binary_crossentropy",
+        metrics=["accuracy"],
+    )
+    return model
+
+
+def do_optimization(opt_pro, build_fn):
+    opt = opt_pro(iterations=2, random_state=32, n_initial_points=1)
+    opt.set_experiment_guidelines(
+        KerasClassifier, build_fn, model_extra_params=dict(batch_size=32, epochs=1, verbose=0)
+    )
+    opt.go()
+    return opt
+
+
+@pytest.mark.parametrize("opt_pro", [DummyOptPro, ET, GBRT, RF])
+@pytest.mark.parametrize("build_fn", [_build_tri_cat, _build_tri_cat_real])
+# @pytest.mark.parametrize(
+#     "build_fn", [_build_tri_cat, _build_tri_cat_real, _build_penta_cat, _build_penta_cat_int],
+# )
+def test_multi_cat_keras_non_bayes(opt_pro, build_fn, hh_assets, env_breast_cancer):
+    opt_0 = do_optimization(opt_pro, build_fn)
+    opt_1 = do_optimization(opt_pro, build_fn)
+    assert len(opt_1.similar_experiments) == 2
+
+
+@pytest.mark.parametrize(
+    "build_fn",
+    [
+        pytest.param(
+            _build_tri_cat,
+            marks=pytest.mark.xfail(reason="BayesianOptPro hates exclusively-Categorical spaces"),
+        ),
+        _build_tri_cat_real,
+    ],
+)
+# @pytest.mark.parametrize(
+#     "build_fn", [_build_tri_cat, _build_tri_cat_real, _build_penta_cat, _build_penta_cat_int],
+# )
+def test_multi_cat_keras_bayes(build_fn, hh_assets, env_breast_cancer):
+    opt_0 = do_optimization(BayesianOptPro, build_fn)
+    opt_1 = do_optimization(BayesianOptPro, build_fn)
+    assert len(opt_1.similar_experiments) == 2


### PR DESCRIPTION
Conditions to summon bug (assume a blood offering has already been made):
   1. Use `BayesianOptPro`
   2. Use exclusively `Categorical` dimensions
   3. At least one of the `Categorical` dimensions must be in `FeatureEngineer`

The above conditions will cause `BayesianOptPro` to break outright. However, problems still arise when omitting `FeatureEngineer`, while searching an exclusively multi-`Categorical` space. The effect of this bug is that saved experiment results are not properly marked as `similar_experiments`. Tests demonstrating the behavior of this second bug are added in 4b60f1a.

When the two `xfail` tests are marked as `xpass`, the bug is probably (hopefully)
fixed