### PR TITLE
Update ReadTheDocs/Coveralls badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ HyperparameterHunter
 ![HyperparameterHunter Overview](docs/media/overview.gif)
 
 [![Build Status](https://travis-ci.org/HunterMcGushion/hyperparameter_hunter.svg?branch=master)](https://travis-ci.org/HunterMcGushion/hyperparameter_hunter)
-[![Documentation Status](https://readthedocs.org/projects/hyperparameter-hunter/badge/?version=latest)](https://hyperparameter-hunter.readthedocs.io/en/latest/?badge=latest)
-[![Coverage Status](https://coveralls.io/repos/github/HunterMcGushion/hyperparameter_hunter/badge.svg?branch=master)](https://coveralls.io/github/HunterMcGushion/hyperparameter_hunter?branch=master)
+[![Documentation Status](https://readthedocs.org/projects/hyperparameter-hunter/badge/?version=stable)](https://hyperparameter-hunter.readthedocs.io/en/latest/?badge=stable)
+[![Coverage Status](https://coveralls.io/repos/github/HunterMcGushion/hyperparameter_hunter/badge.svg?branch=master&service=github)](https://coveralls.io/github/HunterMcGushion/hyperparameter_hunter?branch=master&service=github)
 [![codecov](https://codecov.io/gh/HunterMcGushion/hyperparameter_hunter/branch/master/graph/badge.svg)](https://codecov.io/gh/HunterMcGushion/hyperparameter_hunter)
 [![Maintainability](https://api.codeclimate.com/v1/badges/ef0d004a10ede0b228cc/maintainability)](https://codeclimate.com/github/HunterMcGushion/hyperparameter_hunter/maintainability)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/1413b76fabe2400fab1958e70be593a2)](https://www.codacy.com/app/HunterMcGushion/hyperparameter_hunter?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=HunterMcGushion/hyperparameter_hunter&amp;utm_campaign=Badge_Grade)


### PR DESCRIPTION
- ReadTheDocs badge now links to "stable" build, instead of "latest"
- Attempt to fix Coveralls badge stuck at old values