### PR TITLE
Add `callbacks` kwarg to `CVExperiment`

### DIFF
--- a/hyperparameter_hunter/environment.py
+++ b/hyperparameter_hunter/environment.py
@@ -307,13 +307,19 @@ class Environment:
             score does not meet some threshold you set, for example. `do_full_save` receives the
             Experiment description dict as input, so for help setting `do_full_save`, just look into
             one of your Experiment descriptions
-        experiment_callbacks: :class:`LambdaCallback`, list of :class:`LambdaCallback`, default=None
-            If not None, should be a :class:`LambdaCallback` produced by
-            :func:`.callbacks.bases.lambda_callback`, or a list of such classes. The contents will
-            be added to the MRO of the executed Experiment class by
-            :class:`.experiment_core.ExperimentMeta` at `__call__` time, making
-            `experiment_callbacks` new base classes of the Experiment. See
-            :func:`.callbacks.bases.lambda_callback` for more information
+        experiment_callbacks: `LambdaCallback`, or list of `LambdaCallback` (optional)
+            Callbacks injected directly into Experiments, adding new functionality, or customizing
+            existing processes. Should be a :class:`LambdaCallback` or a list of such classes.
+            `LambdaCallback` can be created using :func:`.callbacks.bases.lambda_callback`, which
+            documents the options for creating callbacks. `experiment_callbacks` will be added to
+            the MRO of the executed Experiment class by :class:`.experiment_core.ExperimentMeta` at
+            `__call__` time, making `experiment_callbacks` new base classes of the Experiment. See
+            :func:`.callbacks.bases.lambda_callback` for more information. Note that the Experiments
+            conducted by OptPros will still benefit from `experiment_callbacks`. The presence of
+            LambdaCallbacks will affect neither Environment keys, nor Experiment keys. In other
+            words, for the purposes of Experiment matching/recording, all other factors being equal,
+            an Experiment with `experiment_callbacks` is considered identical to an Experiment
+            without, despite whatever custom functionality was added by the LambdaCallbacks
         experiment_recorders: List, None, default=None
             If not None, may be a list whose values are tuples of
             (<:class:`recorders.BaseRecorder` descendant>, <str result_path>). The result_path str
@@ -415,6 +421,8 @@ class Environment:
         self.random_seeds = random_seeds
         self.random_seed_bounds = random_seed_bounds
         self.cv_params = cv_params
+        # TODO: Make `cv_params` optional. If not given, use default `cv_type` parameters. Test
+        #   Env keys are identical without `cv_params` and when explicitly given default params
 
         #################### Ancillary Environment Settings ####################
         self.verbose = verbose

--- a/hyperparameter_hunter/experiment_core.py
+++ b/hyperparameter_hunter/experiment_core.py
@@ -128,8 +128,11 @@ class ExperimentMeta(type):
 
         # Add callbacks explicitly supplied on class initialization
         if kwargs.get("callbacks", None) is not None:
-            for callback in kwargs["callbacks"]:
-                instance_bases.append(callback)
+            try:
+                for callback in kwargs["callbacks"]:
+                    instance_bases.append(callback)
+            except TypeError:
+                instance_bases.append(kwargs["callbacks"])
 
         # Infer necessary callbacks based on class initialization inputs
         if G.Env.holdout_dataset is not None:

--- a/hyperparameter_hunter/experiments.py
+++ b/hyperparameter_hunter/experiments.py
@@ -203,6 +203,18 @@ class BaseExperiment(ScoringMixIn):
             documentation for :func:`hyperparameter_hunter.metrics.get_formatted_target_metric` for
             more info. Any values returned by, or used as the `target_metric` input to this function
             are acceptable values for `target_metric`
+        callbacks: `LambdaCallback`, or list of `LambdaCallback` (optional)
+            Callbacks injected directly into concrete Experiment (`CVExperiment`), adding new
+            functionality, or customizing existing processes. Should be a :class:`LambdaCallback` or
+            a list of such classes. `LambdaCallback` can be created using
+            :func:`.callbacks.bases.lambda_callback`, which documents the options for creating
+            callbacks. `callbacks` will be added to the MRO of the Experiment by
+            :class:`.experiment_core.ExperimentMeta` at `__call__` time, making `callbacks` new
+            base classes of the Experiment. See :func:`.callbacks.bases.lambda_callback` for more
+            information. The presence of LambdaCallbacks will not affect Experiment keys. In other
+            words, for the purposes of Experiment matching/recording, all other factors being equal,
+            an Experiment with `callbacks` is considered identical to an Experiment without, despite
+            whatever custom functionality was added by the LambdaCallbacks
 
         See Also
         --------
@@ -714,6 +726,7 @@ class BaseCVExperiment(BaseExperiment):
 # Core CV Experiment Classes:
 ##################################################
 class CVExperiment(BaseCVExperiment, metaclass=ExperimentMeta):
+    # noinspection PyUnusedLocal
     def __init__(
         self,
         model_initializer,
@@ -725,6 +738,7 @@ class CVExperiment(BaseCVExperiment, metaclass=ExperimentMeta):
         do_raise_repeated=False,
         auto_start=True,
         target_metric=None,
+        callbacks=None,  # I get picked up by `ExperimentMeta`
     ):
         BaseCVExperiment.__init__(
             self,

--- a/tests/integration_tests/test_lambda_callback.py
+++ b/tests/integration_tests/test_lambda_callback.py
@@ -1,0 +1,129 @@
+##################################################
+# Import Own Assets
+##################################################
+from hyperparameter_hunter import Environment, CVExperiment, lambda_callback
+from hyperparameter_hunter.callbacks.bases import BaseCallback
+from hyperparameter_hunter.callbacks.recipes import confusion_matrix_oof
+from hyperparameter_hunter.utils.learning_utils import get_diabetes_data
+
+##################################################
+# Import Miscellaneous Assets
+##################################################
+from copy import deepcopy
+import pytest
+
+##################################################
+# Import Learning Assets
+##################################################
+from sklearn.ensemble import AdaBoostRegressor
+
+##################################################
+# Global Settings
+##################################################
+assets_dir = "hyperparameter_hunter/__TEST__HyperparameterHunterAssets__"
+# assets_dir = "hyperparameter_hunter/HyperparameterHunterAssets"
+
+
+def env_lambda_cb(lambda_cbs):
+    """Return an `Environment` using `lambda_cbs` as `experiment_callbacks`
+
+    Parameters
+    ----------
+    lambda_cbs: `LambdaCallback`, list of `LambdaCallback`, or None
+        LambdaCallback values passed to the `Environment`'s `experiment_callbacks` kwarg"""
+    return Environment(
+        train_dataset=get_diabetes_data(target="target"),
+        results_path=assets_dir,
+        metrics=["median_absolute_error"],
+        cv_type="KFold",
+        cv_params=dict(n_splits=3, random_state=1),
+        experiment_callbacks=lambda_cbs,
+    )
+
+
+def exp_lambda_cb(lambda_cbs):
+    """Return a `CVExperiment` with `lambda_cbs` as `callbacks`
+
+    Parameters
+    ----------
+    lambda_cbs: `LambdaCallback`, list of `LambdaCallback`, or None
+        LambdaCallback values passed to the `CVExperiment`'s `callbacks` kwarg"""
+    return CVExperiment(AdaBoostRegressor, callbacks=lambda_cbs)
+
+
+##################################################
+# Dummy LambdaCallbacks
+##################################################
+def dummy_lambda_cb_func():
+    def _on_fold_start(_rep, _fold, _run):
+        print(_rep, _fold, _run)
+
+    return lambda_callback(on_fold_start=_on_fold_start)
+
+
+class DummyLambdaCallbackClass(BaseCallback):
+    def on_run_start(self):
+        print("on_run_start", self._rep, self._fold, self._run)
+
+    def on_run_end(self):
+        print("on_run_end", self._rep, self._fold, self._run)
+
+
+##################################################
+# Test `lambda_callback` Provision
+##################################################
+# noinspection PyUnusedLocal
+@pytest.mark.parametrize(
+    "lambda_cbs",
+    [
+        dummy_lambda_cb_func(),
+        [dummy_lambda_cb_func()],
+        [dummy_lambda_cb_func(), confusion_matrix_oof()],
+        [dummy_lambda_cb_func(), DummyLambdaCallbackClass, confusion_matrix_oof()],
+    ],
+)
+def test_provide_lambda_callbacks(lambda_cbs):
+    """Test that each of the officially-supported methods of providing LambdaCallbacks to an
+    Experiment yields the same MRO. Specifically concerned with using the `experiment_callbacks`
+    kwarg of :class:`~hyperparameter_hunter.environment.Environment` and using the `callbacks`
+    kwarg of :class:`~hyperparameter_hunter.experiments.CVExperiment`. Also sanity check that MROs
+    of Experiments with LambdaCallbacks actually differ from the MRO of a basic Experiment
+
+    Parameters
+    ----------
+    lambda_cbs: `LambdaCallback`, or list of `LambdaCallback`
+        LambdaCallback values passed to the different methods of `lambda_callback` provision"""
+    #################### Via `Environment`'s `experiment_callbacks` ####################
+    env_0 = env_lambda_cb(lambda_cbs)
+    exp_0 = exp_lambda_cb(None)
+    exp_0_mro = deepcopy(type(exp_0).__mro__)
+    # Need to save copy of MRO because it is relative to the CLASS, not the instance, and
+    #   `ExperimentMeta` changes the MRO of the `CVExperiment` class
+
+    #################### Via `CVExperiment`'s `callbacks` ####################
+    env_1 = env_lambda_cb(None)
+    exp_1 = exp_lambda_cb(lambda_cbs)
+    exp_1_mro = deepcopy(type(exp_1).__mro__)
+
+    assert exp_0_mro == exp_1_mro
+    # Can't compare `type(exp_0).__mro__` == `type(exp_1).__mro__` because they will always be
+    #   identical, since (as noted above) `ExperimentMeta`'s changes affect prior `CVExperiment`s
+
+    #################### Baseline Without LambdaCallbacks ####################
+    # Test that both of the above MROs actually differ from the MRO of a basic Experiment
+    env_2 = env_lambda_cb(None)
+    exp_2 = exp_lambda_cb(None)
+    exp_2_mro = deepcopy(type(exp_2).__mro__)
+
+    # NOTE: `assert type(exp_2).__mro__ != type(exp_1).__mro__` would FAIL here for the reasons
+    #   noted in the comments above. This is why the MRO had to be copied each time
+    assert exp_2_mro != exp_0_mro
+    assert exp_2_mro != exp_1_mro
+
+    # Baseline MRO should be missing the LambdaCallbacks added to the earlier Experiments
+    if isinstance(lambda_cbs, list):
+        assert len(exp_2_mro) == (len(exp_0_mro) - len(lambda_cbs))
+        assert len(exp_2_mro) == (len(exp_1_mro) - len(lambda_cbs))
+    else:
+        assert len(exp_2_mro) == (len(exp_0_mro) - 1)
+        assert len(exp_2_mro) == (len(exp_1_mro) - 1)


### PR DESCRIPTION
- Enables passing custom callbacks directly on `CVExperiment`
  initialization as an alternative to `Environment`'s
  `experiment_callbacks`, which are applied to all Experiments/OptPros
- This kwarg is admittedly pretty weird because although it is documented
  in `BaseExperiment`, it only actually exists for `CVExperiment`
- Furthermore, `CVExperiment` itself doesn't do anything with the
  `callbacks` kwarg
- It is instead intercepted by `ExperimentMeta` and applied to the
  `CVExperiment`, as the comment next to the new `callbacks` kwarg notes
- Also updated `Environment`'s `experiment_callbacks` documentation