### PR TITLE
Fix metric evaluation without inverted target transforms bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 <a name="Unreleased"></a>
 ## [Unreleased]
 
+### Bug Fixes
+* Fix bug causing metrics to be evaluated using the transformed targets/predictions, rather than the 
+  inverted (original space) predictions, after performing target transformation via `EngineerStep`
+    * Adds new `Environment` kwarg: `save_transformed_metrics`, which dictates whether metrics are 
+      calculated using transformed targets/predictions (True), or inverted data (False)
+    * Default value of `save_transformed_metrics` is chosen based on dtype of targets. See [#169](https://github.com/HunterMcGushion/hyperparameter_hunter/pull/169)
+
 
 <a name="3.0.0beta0"></a>
 ## [3.0.0beta0] (2019-07-14)

--- a/hyperparameter_hunter/experiments.py
+++ b/hyperparameter_hunter/experiments.py
@@ -379,8 +379,7 @@ class BaseExperiment(ScoringMixIn):
         #################### Build Datasets ####################
         data_kwargs = dict(feature_selector=self.feature_selector, target_column=self.target_column)
         self.data_train = TrainDataset(self.train_dataset, require_data=True, **data_kwargs)
-        # TODO: Might be better to initialize `data_oof` with same data as `data_train`
-        self.data_oof = OOFDataset(None, **data_kwargs)
+        self.data_oof = OOFDataset(self.train_dataset, **data_kwargs)
         self.data_holdout = HoldoutDataset(self.holdout_dataset, **data_kwargs)
         self.data_test = TestDataset(self.test_dataset, feature_selector=self.feature_selector)
 

--- a/hyperparameter_hunter/settings.py
+++ b/hyperparameter_hunter/settings.py
@@ -94,29 +94,6 @@ class G(object):
         target, which is the same form as the original target data. Continuing the example of
         label-encoded target data, and an :class:`feature_engineering.EngineerStep` to one-hot
         encode the target, in this case, label-encoded predictions will be saved.
-    save_transformed_metrics: True
-        Declares manner in which a model's predictions should be evaluated through the provided
-        :attr:`environment.Environment.metrics`, with regard to
-        :class:`feature_engineering.FeatureEngineer` transformations. If no transformation of the
-        target variable takes place (either through :class:`feature_engineering.FeatureEngineer`,
-        :class:`feature_engineering.EngineerStep`, or otherwise), then this setting can be ignored.
-
-        A more descriptive name for this may be "calculate_metrics_using_transformed_predictions",
-        but that's a bit verbose, even by my standards.
-
-        If `save_transformed_metrics` is True (default), and target transformation does occur, then
-        experiment metrics are calculated using the transformed targets and predictions, which is
-        the form returned directly by a fitted model's `predict` method. For example, if target data
-        is label-encoded, and an :class:`feature_engineering.EngineerStep` is used to one-hot encode
-        the target, then metrics functions will receive the following as input:
-        (one-hot-encoded targets, and one-hot-encoded predictions).
-
-        Conversely, if `save_transformed_metrics` is False, and target transformation does occur,
-        then experiment metrics are calculated using the inverse of the transformed targets and
-        predictions, which is same form as the original target data. Continuing the example of
-        label-encoded target data, and an :class:`feature_engineering.EngineerStep` to one-hot
-        encode the target, in this case, metrics functions will receive the following as input:
-        (label-encoded targets, and label-encoded predictions).
     priority_callbacks: Tuple
         Intended for internal use only. The contents of this tuple are inserted at the front of an
         Experiment's list of callback bases via :class:`experiment_core.ExperimentMeta`, ahead of
@@ -139,7 +116,6 @@ class G(object):
 
     #################### Miscellaneous Settings ####################
     save_transformed_predictions = False
-    save_transformed_metrics = True
 
     #################### Internal Settings ####################
     priority_callbacks = tuple()

--- a/hyperparameter_hunter/utils/learning_utils.py
+++ b/hyperparameter_hunter/utils/learning_utils.py
@@ -7,7 +7,13 @@ import pandas as pd
 ###############################################
 # Import Learning Assets
 ###############################################
-from sklearn.datasets import load_boston, load_breast_cancer, load_diabetes, make_classification
+from sklearn.datasets import (
+    load_boston,
+    load_breast_cancer,
+    load_diabetes,
+    load_iris,
+    make_classification,
+)
 
 
 ##################################################
@@ -92,6 +98,8 @@ def get_boston_data():
 
     Examples
     --------
+    >>> pd.set_option("display.max_columns", 10000)  # Ensure all columns are printed below
+    >>> pd.set_option("display.width", 110)  # Ensure all columns are printed below
     >>> get_boston_data().head()
           CRIM    ZN  INDUS  CHAS    NOX     RM   AGE     DIS  RAD    TAX  PTRATIO       B  LSTAT  MEDV
     0  0.00632  18.0   2.31   0.0  0.538  6.575  65.2  4.0900  1.0  296.0     15.3  396.90   4.98  24.0
@@ -121,6 +129,51 @@ def get_diabetes_data(target="progression"):
     data = load_diabetes()
     df = pd.DataFrame(data=data.data, columns=[_.replace(" ", "_") for _ in data.feature_names])
     df[target] = data.target
+    return df
+
+
+def get_iris_data(target="species", use_str_target=False):
+    """Get the Iris classification dataset, formatted as a DataFrame
+
+    Parameters
+    ----------
+    target: String, default="species"
+        What to name the column in `df` that contains the target output values
+    use_str_target: Boolean, default=False
+        If True, replace label-encoded target values with string labels
+
+    Returns
+    -------
+    df: pandas.DataFrame
+        This Iris dataset, with friendly column names
+
+    Examples
+    --------
+    >>> get_iris_data(use_str_target=False).sample(n=5, random_state=32)
+         sepal_length_(cm)  sepal_width_(cm)  petal_length_(cm)  petal_width_(cm)  species
+    55                 5.7               2.8                4.5               1.3        1
+    22                 4.6               3.6                1.0               0.2        0
+    26                 5.0               3.4                1.6               0.4        0
+    56                 6.3               3.3                4.7               1.6        1
+    134                6.1               2.6                5.6               1.4        2
+    >>> get_iris_data(use_str_target=True).sample(n=5, random_state=32)
+         sepal_length_(cm)  sepal_width_(cm)  petal_length_(cm)  petal_width_(cm)     species
+    55                 5.7               2.8                4.5               1.3  versicolor
+    22                 4.6               3.6                1.0               0.2      setosa
+    26                 5.0               3.4                1.6               0.4      setosa
+    56                 6.3               3.3                4.7               1.6  versicolor
+    134                6.1               2.6                5.6               1.4   virginica
+    """
+    data = load_iris()
+    df = pd.DataFrame(data=data.data, columns=[_.replace(" ", "_") for _ in data.feature_names])
+    df[target] = data.target
+
+    if use_str_target:
+        # Replace label-encoded target values with string labels
+        df.loc[:, target].replace(
+            to_replace=dict(zip([0, 1, 2], data.target_names)), value=None, inplace=True
+        )
+
     return df
 
 


### PR DESCRIPTION
- The problem was that metrics were evaluated using the transformed
  targets/predictions after performing target transformation
  (`QuantileTransformer`) via `EngineerStep`
   - This resulted in metrics that were way too impressive compared
     to Experiments without target transformations because they
     were being calculated in the transformed target space, rather
     than the original/inverted space
- To address this, `Environment.__init__` has a new
  `save_transformed_metrics` kwarg--moved from `settings.G`
- Default for `save_transformed_metrics` is chosen based on the
  dtype of `train_dataset`'s target data
- SparkNotes version of documentation:
   - If all targets are numeric, `save_transformed_metric`=False
   - Else, `save_transformed_metric`=True