### PR TITLE
remove the obsolete TODO comment

### DIFF
--- a/hyperparameter_hunter/feature_engineering.py
+++ b/hyperparameter_hunter/feature_engineering.py
@@ -549,7 +549,6 @@ class EngineerStep:
 
         if self.do_validate:
             self.updated_hashes = hash_datasets(new_datasets)
-        # TODO: Check `self.do_validate` here to decide whether to `compare_dataset_columns`
         return new_datasets
 
     def inverse_transform(self, data):


### PR DESCRIPTION
##### SUMMARY
Remove the obsolete TODO comment. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hyperparameter_hunter/feature_engineering.py (line:552)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The pending task of the TODO comment has already performed in the earlier version, but the TODO comment was not removed accordingly at the moment. Please check the following commit: 
https://github.com/HunterMcGushion/hyperparameter_hunter/commit/878c05e3272ab7eb49c166e722bfb01a3b949dee